### PR TITLE
Clean initial setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+tsconfig.tsbuildinfo

--- a/client.ts
+++ b/client.ts
@@ -3,14 +3,11 @@
  * Licensed under the MIT License. See License.txt in the project root for license information.
  * ------------------------------------------------------------------------------------------ */
 
-import '@codingame/monaco-vscode-json-default-extension';
-import * as monaco from 'monaco-editor';
+import * as monaco from '@codingame/monaco-vscode-editor-api';
+// load syntax highlighting for common language like python
+import '@codingame/monaco-vscode-standalone-languages';
 import { initServices } from 'monaco-languageclient/vscode/services';
-import getTextmateServiceOverride from '@codingame/monaco-vscode-textmate-service-override';
-import getThemeServiceOverride from '@codingame/monaco-vscode-theme-service-override';
 import { LogLevel } from '@codingame/monaco-vscode-api';
-// monaco-editor does not supply json highlighting with the json worker,
-// that's why we use the textmate extension from VSCode
 import { ConsoleLogger } from 'monaco-languageclient/tools';
 import { configureDefaultWorkerFactory } from 'monaco-editor-wrapper/workers/workerLoaders';
 import { LanguageClientWrapper, type LanguageClientConfig } from 'monaco-editor-wrapper';
@@ -18,44 +15,26 @@ import { LanguageClientWrapper, type LanguageClientConfig } from 'monaco-editor-
 export const runClient = async () => {
     const logger = new ConsoleLogger(LogLevel.Debug);
     const htmlContainer = document.getElementById('monaco-editor-root')!;
-    await initServices({
-        serviceOverrides: {
-            ...getTextmateServiceOverride(),
-            ...getThemeServiceOverride()
-        },
-        userConfiguration: {
-            json: JSON.stringify({
-                'editor.experimental.asyncTokenization': true
-            })
-        },
-    }, {
-        logger
-    });
-
-    // register the JSON language with Monaco
-    monaco.languages.register({
-        id: 'json',
-        extensions: ['.json', '.jsonc'],
-        aliases: ['JSON', 'json'],
-        mimetypes: ['application/json']
-    });
+    await initServices({});
 
     configureDefaultWorkerFactory(logger);
 
     // create monaco editor
     monaco.editor.create(htmlContainer, {
-        value: `{
-    "$schema": "http://json.schemastore.org/coffeelint",
-    "line_endings": "unix"
-}`,
-        language: 'json',
+        value: `def print_hello():
+
+    x=5
+    print("Hello World!")
+
+print_hello()`,
+        language: 'python',
         automaticLayout: true,
         wordBasedSuggestions: 'off'
     });
 
     const languageClientConfig: LanguageClientConfig = {
         clientOptions: {
-            documentSelector: ['json']
+            documentSelector: ['py']
         },
         connection: {
             options: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,28 +10,25 @@
       "license": "ISC",
       "dependencies": {
         "@codingame/esbuild-import-meta-url-plugin": "^1.0.3",
-        "@codingame/monaco-vscode-api": "^17.1.2",
-        "@codingame/monaco-vscode-editor-api": "^17.1.2",
-        "@codingame/monaco-vscode-extensions-service-override": "^17.1.2",
-        "@codingame/monaco-vscode-json-default-extension": "^17.1.2",
-        "@codingame/monaco-vscode-keybindings-service-override": "^17.1.2",
-        "@codingame/monaco-vscode-rollup-vsix-plugin": "^17.1.2",
-        "@codingame/monaco-vscode-textmate-service-override": "^17.1.2",
-        "@codingame/monaco-vscode-theme-service-override": "^17.1.2",
-        "monaco-editor": "npm:@codingame/monaco-vscode-editor-api@~17.1.2",
-        "monaco-editor-wrapper": "^6.8.0",
-        "monaco-languageclient": "^9.7.0",
+        "@codingame/monaco-vscode-api": "~17.1.2",
+        "@codingame/monaco-vscode-editor-api": "~17.1.2",
+        "@codingame/monaco-vscode-rollup-vsix-plugin": "~17.1.2",
+        "@codingame/monaco-vscode-standalone-languages": "~17.1.2",
+        "monaco-editor-wrapper": "~6.8.0",
+        "monaco-languageclient": "~9.7.0",
+        "typescript": "~5.8.3",
         "vite": "^6.3.5",
         "vscode": "npm:@codingame/monaco-vscode-extension-api@~17.1.2"
       },
       "devDependencies": {
-        "@types/vscode": "^1.100.0"
+        "@types/vscode": "~1.100.0"
       }
     },
     "node_modules/@codingame/esbuild-import-meta-url-plugin": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/@codingame/esbuild-import-meta-url-plugin/-/esbuild-import-meta-url-plugin-1.0.3.tgz",
       "integrity": "sha512-SAIOsWZteIWYAk04BCqQ+ugu8KiJm8EplQbMvxJl905uZv3r+21+XjtGg/zzrbxlVAY1cP+hGAG7z7sBPmy63w==",
+      "license": "ISC",
       "dependencies": {
         "esbuild": ">=0.19.x",
         "import-meta-resolve": "^4.0.0"
@@ -41,6 +38,7 @@
       "version": "17.1.2",
       "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-0764a541-f621-5022-a1f8-cbdadacae5ec-common/-/monaco-vscode-0764a541-f621-5022-a1f8-cbdadacae5ec-common-17.1.2.tgz",
       "integrity": "sha512-7nHerxiPzegyYT1+KKAUIjIhQZWjR8xAFLdt9obMad6zo/dbFs892vc/+SOtvQXWTbtILR1zcAuPgWDh3hKIcg==",
+      "license": "MIT",
       "dependencies": {
         "@codingame/monaco-vscode-api": "17.1.2",
         "@codingame/monaco-vscode-c8227507-8e59-53d6-b50b-71c0ab384cf4-common": "17.1.2"
@@ -50,6 +48,7 @@
       "version": "17.1.2",
       "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-0b087f42-a5a3-5eb9-9bfd-1eebc1bba163-common/-/monaco-vscode-0b087f42-a5a3-5eb9-9bfd-1eebc1bba163-common-17.1.2.tgz",
       "integrity": "sha512-tUiDL9FfmRK7OLOo6YkYNBuS40c7hyynre0xDrf7zQaPUsY1CNz11rJ0dkuRM4g5ZMOmoQXOrIJLRVoKIjvKKw==",
+      "license": "MIT",
       "dependencies": {
         "@codingame/monaco-vscode-7bbc9e7d-eeae-55fc-8bf9-dc2f66e0dc73-common": "17.1.2",
         "@codingame/monaco-vscode-api": "17.1.2"
@@ -59,6 +58,7 @@
       "version": "17.1.2",
       "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-0c06bfba-d24d-5c4d-90cd-b40cefb7f811-common/-/monaco-vscode-0c06bfba-d24d-5c4d-90cd-b40cefb7f811-common-17.1.2.tgz",
       "integrity": "sha512-0Dn9hypipHacgvlFYwGnUd+/qTogcM1CnQk8oE5TbvzJo672SIPLJ7ejTKsDL56N+cI2tq5IQKI/ZFCMJTP/og==",
+      "license": "MIT",
       "dependencies": {
         "@codingame/monaco-vscode-86d65fc6-30f9-5dca-9501-e249de688591-common": "17.1.2",
         "@codingame/monaco-vscode-api": "17.1.2",
@@ -69,6 +69,7 @@
       "version": "17.1.2",
       "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-0cc5da60-f921-59b9-bd8c-a018e93c0a6f-common/-/monaco-vscode-0cc5da60-f921-59b9-bd8c-a018e93c0a6f-common-17.1.2.tgz",
       "integrity": "sha512-5sgoGOUGDBa9KZBVtsAL1xr05H1OflasMY/lx05t4zBVQkeEqUvFMq/ToipBdOumlspW0FJVgmmPPa9SwIVsmw==",
+      "license": "MIT",
       "dependencies": {
         "@codingame/monaco-vscode-api": "17.1.2",
         "@codingame/monaco-vscode-c8227507-8e59-53d6-b50b-71c0ab384cf4-common": "17.1.2",
@@ -79,6 +80,7 @@
       "version": "17.1.2",
       "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-0f5ced28-abde-558b-8652-db8e7d4d64aa-common/-/monaco-vscode-0f5ced28-abde-558b-8652-db8e7d4d64aa-common-17.1.2.tgz",
       "integrity": "sha512-Uhj2mowvJ1DEcElvQAbwwm3/xbeFfW6XBhs/ilzHcOzWQDxEGn+bVzk4W79391QhEmjd3xpqnc25Ar0eXGy3Pw==",
+      "license": "MIT",
       "dependencies": {
         "@codingame/monaco-vscode-api": "17.1.2"
       }
@@ -87,6 +89,7 @@
       "version": "17.1.2",
       "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-1021b67c-93e5-5c78-a270-cbdb2574d980-common/-/monaco-vscode-1021b67c-93e5-5c78-a270-cbdb2574d980-common-17.1.2.tgz",
       "integrity": "sha512-9UGxYOgkKsrbtPetnmKAn7SxIwS52bU9VsKICGN0YXIfVV6S2ABqbbLlw58lQle77nOS57sj3h1Zvd/nE+WgvA==",
+      "license": "MIT",
       "dependencies": {
         "@codingame/monaco-vscode-api": "17.1.2"
       }
@@ -95,6 +98,7 @@
       "version": "17.1.2",
       "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-15626ec7-b165-51e1-8caf-7bcc2ae9b95a-common/-/monaco-vscode-15626ec7-b165-51e1-8caf-7bcc2ae9b95a-common-17.1.2.tgz",
       "integrity": "sha512-xOD4vKbbiUTUFD8jTTgiCm8DV9295FLnota2jGF1LyHPeTchyp9ovIFMaX0pryS0e8PqupQduaqyeRWUkI+mAQ==",
+      "license": "MIT",
       "dependencies": {
         "@codingame/monaco-vscode-api": "17.1.2"
       }
@@ -103,6 +107,7 @@
       "version": "17.1.2",
       "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-1ae7d696-d960-5ac6-97a3-9fe7c8c3a793-common/-/monaco-vscode-1ae7d696-d960-5ac6-97a3-9fe7c8c3a793-common-17.1.2.tgz",
       "integrity": "sha512-8Om/rC/5j2fDwHCP9GOASdZ8RK321nPhjxcBhNigqt3OXj1aSIKmLQ2IoL8DmZzTcQQmxZV8IJuvZOKYTQcJAg==",
+      "license": "MIT",
       "dependencies": {
         "@codingame/monaco-vscode-912ff6c1-e6aa-58cf-bd7f-50cf27bdb591-common": "17.1.2",
         "@codingame/monaco-vscode-api": "17.1.2"
@@ -112,6 +117,7 @@
       "version": "17.1.2",
       "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-1b4486de-4fe4-59c4-9e6d-34f265ff6625-common/-/monaco-vscode-1b4486de-4fe4-59c4-9e6d-34f265ff6625-common-17.1.2.tgz",
       "integrity": "sha512-ISOKyT8KQOI1xFzI/Mq7qdUv3aQF4GgLYOZwNiO9PzB4XVBFPzz2+fAThdjk5J0K+cTrmYzmclxE80hK8F1NfQ==",
+      "license": "MIT",
       "dependencies": {
         "@codingame/monaco-vscode-2a94c04a-b85b-5669-b06b-89c1bfa11cb9-common": "17.1.2",
         "@codingame/monaco-vscode-422642f2-7e3a-5c1c-9e1e-1d3ef1817346-common": "17.1.2",
@@ -126,6 +132,7 @@
       "version": "17.1.2",
       "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-1ba786a5-b7d7-5d26-8a85-ae48ee2a74a4-common/-/monaco-vscode-1ba786a5-b7d7-5d26-8a85-ae48ee2a74a4-common-17.1.2.tgz",
       "integrity": "sha512-OMU0uLdTMeyc5YkCNr3UfFVGkziXStlb5ss/DMeSYaQ8ijonft1kUPG3cMPMjMjCtPK6gWgZ5nkc1fyFyaZN0Q==",
+      "license": "MIT",
       "dependencies": {
         "@codingame/monaco-vscode-7443a901-21f6-577a-9674-42893b997ee0-common": "17.1.2",
         "@codingame/monaco-vscode-api": "17.1.2"
@@ -135,6 +142,7 @@
       "version": "17.1.2",
       "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-1cb11a73-359e-5a2f-9e95-6989cc9858ee-common/-/monaco-vscode-1cb11a73-359e-5a2f-9e95-6989cc9858ee-common-17.1.2.tgz",
       "integrity": "sha512-EOUefJlJiOd9dz3qc2b31yPX+WW+/hgxRAD0zPSaOFVXjjOGqPDUBCA8IvpHCgkmDFx/NZkrpX9FeMi5yrJf4g==",
+      "license": "MIT",
       "dependencies": {
         "@codingame/monaco-vscode-4a0e04a7-c3bd-5fb7-9d3b-4fd047cc9e59-common": "17.1.2",
         "@codingame/monaco-vscode-51fed910-d648-5620-9b80-9232cd79d116-common": "17.1.2",
@@ -146,6 +154,7 @@
       "version": "17.1.2",
       "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-1cc4ea0a-c5b6-54ed-bb60-078a99119b55-common/-/monaco-vscode-1cc4ea0a-c5b6-54ed-bb60-078a99119b55-common-17.1.2.tgz",
       "integrity": "sha512-my6qxKSFBsC3JurqTIHd01308fQDNJfQtFb82m/8UFxze2CSCiDKoq0/xMHQjA8uTJHe0dfO49qfGr2jz/5oKw==",
+      "license": "MIT",
       "dependencies": {
         "@codingame/monaco-vscode-api": "17.1.2",
         "@codingame/monaco-vscode-bed2b49f-41ae-5ed2-b61a-1105500a3f8a-common": "17.1.2"
@@ -155,6 +164,7 @@
       "version": "17.1.2",
       "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-210e86a9-a91b-5273-b05d-390c776dde1f-common/-/monaco-vscode-210e86a9-a91b-5273-b05d-390c776dde1f-common-17.1.2.tgz",
       "integrity": "sha512-kifM1i1ZJY6t06TyzzEpRYXO9ZTcY1Xj7GSyjdpJRDguG+QiZvCDf4Eg/HSwupkPntRIw5VuFiXd/KUORZeceg==",
+      "license": "MIT",
       "dependencies": {
         "@codingame/monaco-vscode-api": "17.1.2"
       }
@@ -163,6 +173,7 @@
       "version": "17.1.2",
       "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-256d5b78-0649-50e9-8354-2807f95f68f4-common/-/monaco-vscode-256d5b78-0649-50e9-8354-2807f95f68f4-common-17.1.2.tgz",
       "integrity": "sha512-nE7dFMrzD9jA2HKbnX7idhbtCbWjvYeKi7BWKBtkU86g01buvUR6MI0ep5JpoNrJeD9jovHRv+5yQLeGZYqYAQ==",
+      "license": "MIT",
       "dependencies": {
         "@codingame/monaco-vscode-34a0ffd3-b9f5-5699-b43b-38af5732f38a-common": "17.1.2",
         "@codingame/monaco-vscode-api": "17.1.2"
@@ -172,6 +183,7 @@
       "version": "17.1.2",
       "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-2a22c7b4-b906-5914-8cd1-3ed912fb738f-common/-/monaco-vscode-2a22c7b4-b906-5914-8cd1-3ed912fb738f-common-17.1.2.tgz",
       "integrity": "sha512-+sxFJX0vSommB5E4CwZk+qm2riFokDeMUaN28M2SsnnQOA7RW3vnZl9uDOqcBZ1HjGjOD0mVa5OMc2Yx5fjIaQ==",
+      "license": "MIT",
       "dependencies": {
         "@codingame/monaco-vscode-api": "17.1.2"
       }
@@ -180,6 +192,7 @@
       "version": "17.1.2",
       "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-2a94c04a-b85b-5669-b06b-89c1bfa11cb9-common/-/monaco-vscode-2a94c04a-b85b-5669-b06b-89c1bfa11cb9-common-17.1.2.tgz",
       "integrity": "sha512-GOKcqRqy9qfdM1ce0aw/x8YAQGEi6gd6n4kIVPqn9gefKIT6VHQGl+vjuDud7aDuaRDilZsTfBhr6JFt/UxkKQ==",
+      "license": "MIT",
       "dependencies": {
         "@codingame/monaco-vscode-4a3ac544-9a61-534c-88df-756262793ef7-common": "17.1.2",
         "@codingame/monaco-vscode-api": "17.1.2",
@@ -190,6 +203,7 @@
       "version": "17.1.2",
       "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-2cbab29e-9393-5de6-b701-9a9555360b6b-common/-/monaco-vscode-2cbab29e-9393-5de6-b701-9a9555360b6b-common-17.1.2.tgz",
       "integrity": "sha512-6WBscptRWayTnw713lm0dGfIEBu5dEH724FvoN9yKF1dw9WkhYki9UOfW+YoPklRaU47yzVwosqRDwaG6vEgxg==",
+      "license": "MIT",
       "dependencies": {
         "@codingame/monaco-vscode-407531d3-fdae-5387-8c41-49ba0e9574b5-common": "17.1.2",
         "@codingame/monaco-vscode-api": "17.1.2"
@@ -199,6 +213,7 @@
       "version": "17.1.2",
       "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-2f06fe84-148e-5e6b-a7ca-c7989c5f128a-common/-/monaco-vscode-2f06fe84-148e-5e6b-a7ca-c7989c5f128a-common-17.1.2.tgz",
       "integrity": "sha512-fbKDjMjm3TApVMrpG65Dh+QfAljA8G/FtnqlKq6HR0TC1MQwtQDJM6WplTyRNGBRpjN+N34IQS/gHGLGQBmIFg==",
+      "license": "MIT",
       "dependencies": {
         "@codingame/monaco-vscode-api": "17.1.2",
         "@codingame/monaco-vscode-c8227507-8e59-53d6-b50b-71c0ab384cf4-common": "17.1.2"
@@ -208,6 +223,7 @@
       "version": "17.1.2",
       "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-3109a756-1f83-5d09-945b-9f0fcad928f0-common/-/monaco-vscode-3109a756-1f83-5d09-945b-9f0fcad928f0-common-17.1.2.tgz",
       "integrity": "sha512-UWtjHa890DK4ljMQausS0fwK4OHYEn52n53xtUeMXB+NP2bTl2VUEf0Oo0OYcUrks1X7XjfPJSN2sUK1X3Y0cQ==",
+      "license": "MIT",
       "dependencies": {
         "@codingame/monaco-vscode-5945a5e2-a66c-5a82-bd2c-1965724b29eb-common": "17.1.2",
         "@codingame/monaco-vscode-95ea5c7c-15cf-50aa-8e24-38039b06b4a6-common": "17.1.2",
@@ -221,6 +237,7 @@
       "version": "17.1.2",
       "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-324f9a6e-6231-5bfc-af17-e147abd2dfd2-common/-/monaco-vscode-324f9a6e-6231-5bfc-af17-e147abd2dfd2-common-17.1.2.tgz",
       "integrity": "sha512-rdNCUV96NPn7gco1m8sWFM24qgIBpQFHu3SsjF07n5WKZPXXyDQgbNkYMSSLS1ZYxcNPhkecSjAgfM5LJaoihQ==",
+      "license": "MIT",
       "dependencies": {
         "@codingame/monaco-vscode-86d65fc6-30f9-5dca-9501-e249de688591-common": "17.1.2",
         "@codingame/monaco-vscode-api": "17.1.2",
@@ -231,6 +248,7 @@
       "version": "17.1.2",
       "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-33833ac7-3af3-5e9d-8fb9-11838d852c59-common/-/monaco-vscode-33833ac7-3af3-5e9d-8fb9-11838d852c59-common-17.1.2.tgz",
       "integrity": "sha512-8yLI+NkUZXjPeLbXajw4JcAwUu3cfx1FwgQhaF1avacAuojYils/UZg+VA7qPeMdP+YaZ6So1BRnlMAivbbSbA==",
+      "license": "MIT",
       "dependencies": {
         "@codingame/monaco-vscode-api": "17.1.2"
       }
@@ -239,6 +257,7 @@
       "version": "17.1.2",
       "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-34a0ffd3-b9f5-5699-b43b-38af5732f38a-common/-/monaco-vscode-34a0ffd3-b9f5-5699-b43b-38af5732f38a-common-17.1.2.tgz",
       "integrity": "sha512-I9eVf/R8gEBrvnF26zXOJ3gF7mSH3HFuKYwHbuvDxQJhsd58QzPQDLv0RVQnhb0h3C2M8r5SIg9Fw+dmqDf2Tw==",
+      "license": "MIT",
       "dependencies": {
         "@codingame/monaco-vscode-api": "17.1.2"
       }
@@ -247,6 +266,7 @@
       "version": "17.1.2",
       "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-3cf6a388-482f-5484-a806-0525ad9ad8af-common/-/monaco-vscode-3cf6a388-482f-5484-a806-0525ad9ad8af-common-17.1.2.tgz",
       "integrity": "sha512-psfD9aR3Bg/0w7fmLuWiegCVnbEmB7MPy9TVVW/Rg7hjX2aaJKlNAzM1eQNrH8j4n6A6okiJeu3MZ3niRjiBkA==",
+      "license": "MIT",
       "dependencies": {
         "@codingame/monaco-vscode-65619f8f-0eab-5d8b-855a-43b6353fe527-common": "17.1.2",
         "@codingame/monaco-vscode-86d65fc6-30f9-5dca-9501-e249de688591-common": "17.1.2",
@@ -262,6 +282,7 @@
       "version": "17.1.2",
       "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-407531d3-fdae-5387-8c41-49ba0e9574b5-common/-/monaco-vscode-407531d3-fdae-5387-8c41-49ba0e9574b5-common-17.1.2.tgz",
       "integrity": "sha512-wQKZy8+edgEy/ei8dEWW00s1FFRk49FOei7YG5z/yMdfXqcktXfHrK0/ZYrypC91zRAamiZ+++nNyAgbZOd4kg==",
+      "license": "MIT",
       "dependencies": {
         "@codingame/monaco-vscode-api": "17.1.2"
       }
@@ -270,6 +291,7 @@
       "version": "17.1.2",
       "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-40cada32-7e9c-528a-81fc-766e4da54147-common/-/monaco-vscode-40cada32-7e9c-528a-81fc-766e4da54147-common-17.1.2.tgz",
       "integrity": "sha512-14H0VaaDnNt2D5Vaj7ZtFgVaeC2SJArd9vuz2VEtRr0IYwLJRpT46V7xdVsKz6OUjO0rDp4qOObN2dHM/bFHVg==",
+      "license": "MIT",
       "dependencies": {
         "@codingame/monaco-vscode-2cbab29e-9393-5de6-b701-9a9555360b6b-common": "17.1.2",
         "@codingame/monaco-vscode-34a0ffd3-b9f5-5699-b43b-38af5732f38a-common": "17.1.2",
@@ -281,6 +303,7 @@
       "version": "17.1.2",
       "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-422642f2-7e3a-5c1c-9e1e-1d3ef1817346-common/-/monaco-vscode-422642f2-7e3a-5c1c-9e1e-1d3ef1817346-common-17.1.2.tgz",
       "integrity": "sha512-lwVAYxZWjIHBgmzjw1qt9vrZIB1TUDqqEedWnWMHzVeQbNvrjqGimkVJz4bcVqcU/blalH+MsdgwKKG8Y9amkQ==",
+      "license": "MIT",
       "dependencies": {
         "@codingame/monaco-vscode-api": "17.1.2"
       }
@@ -289,6 +312,7 @@
       "version": "17.1.2",
       "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-42931eb9-e564-530c-bafc-fa23ab43a070-common/-/monaco-vscode-42931eb9-e564-530c-bafc-fa23ab43a070-common-17.1.2.tgz",
       "integrity": "sha512-NKmzI7pgk9jZuckesyi40AtwW14Nhj3zlBOZdrS//4efFhfSebRmznim5lsudt+WAfyNoqvKN1AXX6afX3OEhg==",
+      "license": "MIT",
       "dependencies": {
         "@codingame/monaco-vscode-0b087f42-a5a3-5eb9-9bfd-1eebc1bba163-common": "17.1.2",
         "@codingame/monaco-vscode-9f229325-8261-585c-a552-16085958c680-common": "17.1.2",
@@ -301,6 +325,7 @@
       "version": "17.1.2",
       "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-494be54c-bd37-5b3c-af70-02f086e28768-common/-/monaco-vscode-494be54c-bd37-5b3c-af70-02f086e28768-common-17.1.2.tgz",
       "integrity": "sha512-NaxTl/Jyq6bK9qNSIkc0da2eBx/GvABDCd+dzr8yobBhJDccRC3WfX+gluDWMVmRetUJduG+bxXqqiRYMapXBw==",
+      "license": "MIT",
       "dependencies": {
         "@codingame/monaco-vscode-api": "17.1.2",
         "@codingame/monaco-vscode-c8227507-8e59-53d6-b50b-71c0ab384cf4-common": "17.1.2"
@@ -310,6 +335,7 @@
       "version": "17.1.2",
       "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-4a0e04a7-c3bd-5fb7-9d3b-4fd047cc9e59-common/-/monaco-vscode-4a0e04a7-c3bd-5fb7-9d3b-4fd047cc9e59-common-17.1.2.tgz",
       "integrity": "sha512-FpRwZ0L8M8Xqq2uXgdTttJzMa5s47w3RWLWGKLhzI40G/8iRFEpdZcNke87D3Iw4HMEjUGorrp4EBFI+dZ+pnw==",
+      "license": "MIT",
       "dependencies": {
         "@codingame/monaco-vscode-api": "17.1.2"
       }
@@ -318,6 +344,7 @@
       "version": "17.1.2",
       "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-4a316137-39d1-5d77-8b53-112db3547c1e-common/-/monaco-vscode-4a316137-39d1-5d77-8b53-112db3547c1e-common-17.1.2.tgz",
       "integrity": "sha512-QeuPcG/hbyLGTJfiY/HbG97mIV6AqW1Qqd1wLYGovYZ4sRBs9+HsCJOtWI/XMyAt/+nleVlf8o3IMJ0xjRELgA==",
+      "license": "MIT",
       "dependencies": {
         "@codingame/monaco-vscode-65619f8f-0eab-5d8b-855a-43b6353fe527-common": "17.1.2",
         "@codingame/monaco-vscode-a7c9ae3c-16d2-5d17-86b2-981be7094566-common": "17.1.2",
@@ -331,6 +358,7 @@
       "version": "17.1.2",
       "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-4a3ac544-9a61-534c-88df-756262793ef7-common/-/monaco-vscode-4a3ac544-9a61-534c-88df-756262793ef7-common-17.1.2.tgz",
       "integrity": "sha512-Y3tbxbjgIWIHxZ9aoh5//52ARUhzEsOZybAa0Ajyrhx+1Py+g0ul6TC5RISzcemBPMIm6j5snqKIyZq5i/YkMw==",
+      "license": "MIT",
       "dependencies": {
         "@codingame/monaco-vscode-api": "17.1.2"
       }
@@ -339,6 +367,7 @@
       "version": "17.1.2",
       "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-51fed910-d648-5620-9b80-9232cd79d116-common/-/monaco-vscode-51fed910-d648-5620-9b80-9232cd79d116-common-17.1.2.tgz",
       "integrity": "sha512-pvgYB84PMUVoCbmFM3g3fTUS1Y4S9j4TKfqEosoDhTmrVMjxai+Vf9j2sdMU3E1BP828yzy85LUt843sEcGT4Q==",
+      "license": "MIT",
       "dependencies": {
         "@codingame/monaco-vscode-api": "17.1.2"
       }
@@ -347,6 +376,7 @@
       "version": "17.1.2",
       "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-523730aa-81e6-55d7-9916-87ad537fe087-common/-/monaco-vscode-523730aa-81e6-55d7-9916-87ad537fe087-common-17.1.2.tgz",
       "integrity": "sha512-0FijkWb6Hu+TXAYLmG2+5/w+a0YoVNOho2M+ylemLcKdC2UFUnBx6D2xRu50oYv1AD6yQLXPTt6uOPRP2tWpSw==",
+      "license": "MIT",
       "dependencies": {
         "@codingame/monaco-vscode-5945a5e2-a66c-5a82-bd2c-1965724b29eb-common": "17.1.2",
         "@codingame/monaco-vscode-86d65fc6-30f9-5dca-9501-e249de688591-common": "17.1.2",
@@ -359,6 +389,7 @@
       "version": "17.1.2",
       "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-5452e2b7-9081-5f95-839b-4ab3544ce28f-common/-/monaco-vscode-5452e2b7-9081-5f95-839b-4ab3544ce28f-common-17.1.2.tgz",
       "integrity": "sha512-L6PLT60OngfKjlJ7adopVIcpLiYOIM/WJV7buawbpzDprLm+BjUF4iMm6uCL3C717T3gOoXjj7NyoL+LStHA6g==",
+      "license": "MIT",
       "dependencies": {
         "@codingame/monaco-vscode-1cc4ea0a-c5b6-54ed-bb60-078a99119b55-common": "17.1.2",
         "@codingame/monaco-vscode-api": "17.1.2"
@@ -368,6 +399,7 @@
       "version": "17.1.2",
       "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-5945a5e2-a66c-5a82-bd2c-1965724b29eb-common/-/monaco-vscode-5945a5e2-a66c-5a82-bd2c-1965724b29eb-common-17.1.2.tgz",
       "integrity": "sha512-mfYXdUuPFlwVJmLkX1TaAmW+A95GQ14tioAoc//sxiX7Bxja1LsMCe42/h9OBpydpDhRsMzNAkmQmberRi0p5w==",
+      "license": "MIT",
       "dependencies": {
         "@codingame/monaco-vscode-3cf6a388-482f-5484-a806-0525ad9ad8af-common": "17.1.2",
         "@codingame/monaco-vscode-86d65fc6-30f9-5dca-9501-e249de688591-common": "17.1.2",
@@ -382,6 +414,7 @@
       "version": "17.1.2",
       "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-65619f8f-0eab-5d8b-855a-43b6353fe527-common/-/monaco-vscode-65619f8f-0eab-5d8b-855a-43b6353fe527-common-17.1.2.tgz",
       "integrity": "sha512-R7Dnt+CScKG65kSyMvXeVozSoxZFfzhoPXE/Rt520vx/9HzhXZvtZv+GLMlrgBBOnh0HH6Zfnkz28xM15tWkfg==",
+      "license": "MIT",
       "dependencies": {
         "@codingame/monaco-vscode-api": "17.1.2"
       }
@@ -390,6 +423,7 @@
       "version": "17.1.2",
       "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-6845754f-e617-5ed9-8aaa-6ca3653a9532-common/-/monaco-vscode-6845754f-e617-5ed9-8aaa-6ca3653a9532-common-17.1.2.tgz",
       "integrity": "sha512-SeqPN522QjZOtHMq+wkAhO9uXIu1QXL3tsTQog8g8wxH8BztYEJy6x8d4a3d/dhOo0MvkKARhbgsBzLvAHjAmA==",
+      "license": "MIT",
       "dependencies": {
         "@codingame/monaco-vscode-api": "17.1.2"
       }
@@ -398,6 +432,7 @@
       "version": "17.1.2",
       "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-6980eeab-47bb-5a48-8e15-32caf0785565-common/-/monaco-vscode-6980eeab-47bb-5a48-8e15-32caf0785565-common-17.1.2.tgz",
       "integrity": "sha512-VGqWgiKMMVqY6KAvtUR5F2Uh/mnRMxsF1U2eAXnfXd3Uz7XQY15Zv0p4in9G7oFR0P8sUehXi3UYh4ENbKTO/g==",
+      "license": "MIT",
       "dependencies": {
         "@codingame/monaco-vscode-0cc5da60-f921-59b9-bd8c-a018e93c0a6f-common": "17.1.2",
         "@codingame/monaco-vscode-40cada32-7e9c-528a-81fc-766e4da54147-common": "17.1.2",
@@ -415,6 +450,7 @@
       "version": "17.1.2",
       "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-6bf85d7b-e6e3-54e9-9bc1-7e08d663f0f6-common/-/monaco-vscode-6bf85d7b-e6e3-54e9-9bc1-7e08d663f0f6-common-17.1.2.tgz",
       "integrity": "sha512-E6NJH+s+XaiuELe+6EQnCaP7rjv72/5KVT3w5x/HFv2tddqOd9Ccquv3KewqvUG7ghF/y24YkFkIongRp/9vJQ==",
+      "license": "MIT",
       "dependencies": {
         "@codingame/monaco-vscode-0cc5da60-f921-59b9-bd8c-a018e93c0a6f-common": "17.1.2",
         "@codingame/monaco-vscode-85886bdb-61c5-52f1-8eb7-d1d32f6f8cbd-common": "17.1.2",
@@ -428,6 +464,7 @@
       "version": "17.1.2",
       "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-7443a901-21f6-577a-9674-42893b997ee0-common/-/monaco-vscode-7443a901-21f6-577a-9674-42893b997ee0-common-17.1.2.tgz",
       "integrity": "sha512-KhwnkYkiCY87ZqewINvnGpdflK80MPlSt9VZD+m32J71BlvJs5iJCw0Wj6UpTm2gb/fNju+12eDlJxxK7oUbcA==",
+      "license": "MIT",
       "dependencies": {
         "@codingame/monaco-vscode-api": "17.1.2"
       }
@@ -436,6 +473,7 @@
       "version": "17.1.2",
       "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-7bbc9e7d-eeae-55fc-8bf9-dc2f66e0dc73-common/-/monaco-vscode-7bbc9e7d-eeae-55fc-8bf9-dc2f66e0dc73-common-17.1.2.tgz",
       "integrity": "sha512-gEqZf8MS0mY/oS1OuHQh2o+Niul2z27IdAcIzkhZJQ3/9IK8zYrm8qJjNFSNh3JQH5OPcNIkC7xUWXiZQIbIVg==",
+      "license": "MIT",
       "dependencies": {
         "@codingame/monaco-vscode-api": "17.1.2"
       }
@@ -444,6 +482,7 @@
       "version": "17.1.2",
       "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-7f39b6f1-3542-5430-8760-0f404d7a7cee-common/-/monaco-vscode-7f39b6f1-3542-5430-8760-0f404d7a7cee-common-17.1.2.tgz",
       "integrity": "sha512-zbkzrids59nUNMByTqOAxLK0HVFUPjTrspw0XKW5mK1W058AZ1dO8q3oTKco/wuqXphpnfB+LGLsQaUNO2aKUg==",
+      "license": "MIT",
       "dependencies": {
         "@codingame/monaco-vscode-324f9a6e-6231-5bfc-af17-e147abd2dfd2-common": "17.1.2",
         "@codingame/monaco-vscode-9c72783f-914c-50be-b9ef-da16356d81a8-common": "17.1.2",
@@ -456,6 +495,7 @@
       "version": "17.1.2",
       "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-85886bdb-61c5-52f1-8eb7-d1d32f6f8cbd-common/-/monaco-vscode-85886bdb-61c5-52f1-8eb7-d1d32f6f8cbd-common-17.1.2.tgz",
       "integrity": "sha512-L2Zmld7L2nCw8q9/xXKz/T56IXKBHsQ98i46lOUU/yDM4GH1tGN2vCqBMWc01a2HUQYYv+1CWkb+hq3fczsDlg==",
+      "license": "MIT",
       "dependencies": {
         "@codingame/monaco-vscode-api": "17.1.2",
         "@codingame/monaco-vscode-c8227507-8e59-53d6-b50b-71c0ab384cf4-common": "17.1.2"
@@ -465,6 +505,7 @@
       "version": "17.1.2",
       "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-86d65fc6-30f9-5dca-9501-e249de688591-common/-/monaco-vscode-86d65fc6-30f9-5dca-9501-e249de688591-common-17.1.2.tgz",
       "integrity": "sha512-6r9KyhRuUjm8SjxKfQNGt+0oN9Nc6tCYh4Qh8U9mIGyDVfCzIEOspIRiiHYVDSUvATVawvPu1chaMtE/T2E1Zw==",
+      "license": "MIT",
       "dependencies": {
         "@codingame/monaco-vscode-api": "17.1.2",
         "@codingame/monaco-vscode-c8227507-8e59-53d6-b50b-71c0ab384cf4-common": "17.1.2"
@@ -474,6 +515,7 @@
       "version": "17.1.2",
       "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-897bebad-39df-57cb-8a57-36a271d038be-common/-/monaco-vscode-897bebad-39df-57cb-8a57-36a271d038be-common-17.1.2.tgz",
       "integrity": "sha512-DluMhZaGdl4/rbt92wDihLL5Ipgr2zCXTxpz1334DzoT+zMzOyB6MXBekVEdM1bMU4cq6vtRV0cAi3id2KyaCg==",
+      "license": "MIT",
       "dependencies": {
         "@codingame/monaco-vscode-api": "17.1.2"
       }
@@ -482,6 +524,7 @@
       "version": "17.1.2",
       "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-89a82baf-8ded-5b2f-b8af-e5fbd72dc5ad-common/-/monaco-vscode-89a82baf-8ded-5b2f-b8af-e5fbd72dc5ad-common-17.1.2.tgz",
       "integrity": "sha512-WAWht7Y5aPC6WBX3RgPMz+60Yw0P9osg0TzXKMj57ISyhtaEUnnF5sq/qOeActQSinjNpHAwF+8FU0ATiWvULg==",
+      "license": "MIT",
       "dependencies": {
         "@codingame/monaco-vscode-256d5b78-0649-50e9-8354-2807f95f68f4-common": "17.1.2",
         "@codingame/monaco-vscode-api": "17.1.2"
@@ -491,6 +534,7 @@
       "version": "17.1.2",
       "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-8ccb7637-50ea-5359-97bf-00015d7fe567-common/-/monaco-vscode-8ccb7637-50ea-5359-97bf-00015d7fe567-common-17.1.2.tgz",
       "integrity": "sha512-TfP+WgVOkmO1V9TRvJH3lo/7Hm2FIzeS2vNrNMmPJ8iegRn8p9bBUG+VapG3eXe8Gx8ajHOraxXLGIYEIn3LlQ==",
+      "license": "MIT",
       "dependencies": {
         "@codingame/monaco-vscode-210e86a9-a91b-5273-b05d-390c776dde1f-common": "17.1.2",
         "@codingame/monaco-vscode-86d65fc6-30f9-5dca-9501-e249de688591-common": "17.1.2",
@@ -504,6 +548,7 @@
       "version": "17.1.2",
       "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-912ff6c1-e6aa-58cf-bd7f-50cf27bdb591-common/-/monaco-vscode-912ff6c1-e6aa-58cf-bd7f-50cf27bdb591-common-17.1.2.tgz",
       "integrity": "sha512-Gl8o966hBJ+BYA11J3TXEwcFE26RTcTkuJXdmt8DP9nsOgwItPlnWJ1DvEV7K/Zb1gA3GxCokF9BTF2iwC3reA==",
+      "license": "MIT",
       "dependencies": {
         "@codingame/monaco-vscode-api": "17.1.2"
       }
@@ -512,6 +557,7 @@
       "version": "17.1.2",
       "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-95ea5c7c-15cf-50aa-8e24-38039b06b4a6-common/-/monaco-vscode-95ea5c7c-15cf-50aa-8e24-38039b06b4a6-common-17.1.2.tgz",
       "integrity": "sha512-dZrq8mJVHW+eTH2nHe/UFDWhARFIn0rcH5FvTqBVraglOdJlHBQAt0w3IUkolqsL0S5pGRUmeXwNMWkzx3We2A==",
+      "license": "MIT",
       "dependencies": {
         "@codingame/monaco-vscode-9c72783f-914c-50be-b9ef-da16356d81a8-common": "17.1.2",
         "@codingame/monaco-vscode-api": "17.1.2"
@@ -521,6 +567,7 @@
       "version": "17.1.2",
       "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-96e83782-7f38-572e-8787-02e981f1c54f-common/-/monaco-vscode-96e83782-7f38-572e-8787-02e981f1c54f-common-17.1.2.tgz",
       "integrity": "sha512-76Bu4lN6BkTJPn0JcLKjxTW4u8AcThU0M91b3NZfEnAMyltAPMhzjejUmKCcoHoneH5VMDvcvPSQ59M8J1Agyw==",
+      "license": "MIT",
       "dependencies": {
         "@codingame/monaco-vscode-0764a541-f621-5022-a1f8-cbdadacae5ec-common": "17.1.2",
         "@codingame/monaco-vscode-2cbab29e-9393-5de6-b701-9a9555360b6b-common": "17.1.2",
@@ -533,6 +580,7 @@
       "version": "17.1.2",
       "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-97284942-b044-5fbb-b53b-3f46d2468746-common/-/monaco-vscode-97284942-b044-5fbb-b53b-3f46d2468746-common-17.1.2.tgz",
       "integrity": "sha512-mdOzLmLB9vsa8OT0AqK9d4C+zSEPGSGZ1hHoVx+t5WtaS7GY5kYNy0OQ3KexOfqnxy/+DrTdcgPMX4v88Oe1cQ==",
+      "license": "MIT",
       "dependencies": {
         "@codingame/monaco-vscode-api": "17.1.2"
       }
@@ -541,6 +589,7 @@
       "version": "17.1.2",
       "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-9a1a5840-af83-5d07-a156-ba32a36c5c4b-common/-/monaco-vscode-9a1a5840-af83-5d07-a156-ba32a36c5c4b-common-17.1.2.tgz",
       "integrity": "sha512-sfgMuBdICqiz1F40ZYhipPdc1r8zV9/yXisF7hLdH4lxw7C0Ke9Jk3ggCvsmGAHhVHe1XJMPLOyq3CEwnYKVBw==",
+      "license": "MIT",
       "dependencies": {
         "@codingame/monaco-vscode-34a0ffd3-b9f5-5699-b43b-38af5732f38a-common": "17.1.2",
         "@codingame/monaco-vscode-api": "17.1.2"
@@ -550,6 +599,7 @@
       "version": "17.1.2",
       "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-9c72783f-914c-50be-b9ef-da16356d81a8-common/-/monaco-vscode-9c72783f-914c-50be-b9ef-da16356d81a8-common-17.1.2.tgz",
       "integrity": "sha512-xLMTkwHq+o8m4nu+1Q+WIXO4bvyIQSSkOs3Hxw1louYFq1bjgwxP6QZ7/mDEDdwqEje0B3n3khoyMBEvAQeRVg==",
+      "license": "MIT",
       "dependencies": {
         "@codingame/monaco-vscode-api": "17.1.2",
         "@codingame/monaco-vscode-c8227507-8e59-53d6-b50b-71c0ab384cf4-common": "17.1.2",
@@ -560,6 +610,7 @@
       "version": "17.1.2",
       "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-9c84f943-bcb5-5bcf-92a6-91f66a732f26-common/-/monaco-vscode-9c84f943-bcb5-5bcf-92a6-91f66a732f26-common-17.1.2.tgz",
       "integrity": "sha512-bXmFoiafWZN29O7yPxT5Cjg/MxakZTJnF/xzWxXbK0J9TlIAQLqgJScexCBOtgE3nTRHFNYwRE3bDe8omlwu+g==",
+      "license": "MIT",
       "dependencies": {
         "@codingame/monaco-vscode-api": "17.1.2"
       }
@@ -568,6 +619,7 @@
       "version": "17.1.2",
       "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-9d0168a3-519b-57f3-9bcc-89efc41f951a-common/-/monaco-vscode-9d0168a3-519b-57f3-9bcc-89efc41f951a-common-17.1.2.tgz",
       "integrity": "sha512-NrLq0swNXV04FhOuWSSC2K/HhaS6e9/euw3MQ1jZIrJMBTUC3YK9+V51mPo4l6GwAGNsp/GsYeeuxYaZiit6gw==",
+      "license": "MIT",
       "dependencies": {
         "@codingame/monaco-vscode-7443a901-21f6-577a-9674-42893b997ee0-common": "17.1.2",
         "@codingame/monaco-vscode-api": "17.1.2"
@@ -577,6 +629,7 @@
       "version": "17.1.2",
       "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-9ee79c1a-3f03-568b-8eac-b02513a98b68-common/-/monaco-vscode-9ee79c1a-3f03-568b-8eac-b02513a98b68-common-17.1.2.tgz",
       "integrity": "sha512-rmnGQ0fR6ITrvCTXbe5mPZDSSmHVpHwSRbQkmeApfnMSXMGKLTsjsX/Ox+gO70/9f8Wlq7ZidBRBQoofVzj7lw==",
+      "license": "MIT",
       "dependencies": {
         "@codingame/monaco-vscode-api": "17.1.2",
         "@codingame/monaco-vscode-b4efa70b-52b9-5670-ab5c-f10b10b6834e-common": "17.1.2"
@@ -586,6 +639,7 @@
       "version": "17.1.2",
       "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-9efc1f50-c7de-55d6-8b28-bcc88bd49b5a-common/-/monaco-vscode-9efc1f50-c7de-55d6-8b28-bcc88bd49b5a-common-17.1.2.tgz",
       "integrity": "sha512-E3OsenajfsX1jTcXJycTaVAJVhw2Gm4iRKpz3u7NUBf/t2OWfFGciDrtAjP/3ibR94TLaXrHEpcGm4VupjZkUA==",
+      "license": "MIT",
       "dependencies": {
         "@codingame/monaco-vscode-0764a541-f621-5022-a1f8-cbdadacae5ec-common": "17.1.2",
         "@codingame/monaco-vscode-65619f8f-0eab-5d8b-855a-43b6353fe527-common": "17.1.2",
@@ -603,6 +657,7 @@
       "version": "17.1.2",
       "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-9f229325-8261-585c-a552-16085958c680-common/-/monaco-vscode-9f229325-8261-585c-a552-16085958c680-common-17.1.2.tgz",
       "integrity": "sha512-LmDCRvm34KZuAbmq3BZBE8tTTVYPZw246iXwzVQwdjwWmi+beSuGdcuUJbPguKOW2SOkkiD0pQSVUqeCfFkxFw==",
+      "license": "MIT",
       "dependencies": {
         "@codingame/monaco-vscode-1ae7d696-d960-5ac6-97a3-9fe7c8c3a793-common": "17.1.2",
         "@codingame/monaco-vscode-210e86a9-a91b-5273-b05d-390c776dde1f-common": "17.1.2",
@@ -619,6 +674,7 @@
       "version": "17.1.2",
       "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-a2719803-af40-5ae9-a29f-8a2231c33056-common/-/monaco-vscode-a2719803-af40-5ae9-a29f-8a2231c33056-common-17.1.2.tgz",
       "integrity": "sha512-ZfHyNcO60FJ6PubhlewxP+u9l6MgFNwLebdp6KViSKCQVCGsNxz1FxQJH0awP6HCjMPyqOXnjoELZnLFdnyK+w==",
+      "license": "MIT",
       "dependencies": {
         "@codingame/monaco-vscode-api": "17.1.2"
       }
@@ -627,6 +683,7 @@
       "version": "17.1.2",
       "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-a3eaa464-944c-5b8f-8886-213068ba4897-common/-/monaco-vscode-a3eaa464-944c-5b8f-8886-213068ba4897-common-17.1.2.tgz",
       "integrity": "sha512-RPZDKmxFHOc7mUvkxfztCLAaUuhaVp1N+rv/CmXXvz/xyU40ukPw5KM1gIftS5cLBqvtOvPVzvEOoSifOKtGDw==",
+      "license": "MIT",
       "dependencies": {
         "@codingame/monaco-vscode-api": "17.1.2"
       }
@@ -635,6 +692,7 @@
       "version": "17.1.2",
       "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-a7c9ae3c-16d2-5d17-86b2-981be7094566-common/-/monaco-vscode-a7c9ae3c-16d2-5d17-86b2-981be7094566-common-17.1.2.tgz",
       "integrity": "sha512-CABeYtHezaxd3oa49HbgRMH3P7r+OBkFf/IXLtVHc4gVQDhlCQXxyunwj2WtEuJx0tB3dBKBt3zReqwlSDK/XA==",
+      "license": "MIT",
       "dependencies": {
         "@codingame/monaco-vscode-api": "17.1.2"
       }
@@ -643,6 +701,7 @@
       "version": "17.1.2",
       "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-abed5a84-8a82-5f84-9412-88a736235bae-common/-/monaco-vscode-abed5a84-8a82-5f84-9412-88a736235bae-common-17.1.2.tgz",
       "integrity": "sha512-f3DTqnDqgyqUc8LKvWFYOD3yn6n71mDkLE27AGSfEOivvk9mImpmmrQHWoUnwic3wEHOemIbfY4QHqYS7ZLfoA==",
+      "license": "MIT",
       "dependencies": {
         "@codingame/monaco-vscode-api": "17.1.2"
       }
@@ -651,6 +710,7 @@
       "version": "17.1.2",
       "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-api/-/monaco-vscode-api-17.1.2.tgz",
       "integrity": "sha512-wu2G1lIfrr9DOIJMo9rKopxp/hi/wnIeSK5seCma5Pg/YJDUOPKjl1i2zdC7qSanrALuYxq0S8+QzETCVpr+ag==",
+      "license": "MIT",
       "dependencies": {
         "@codingame/monaco-vscode-base-service-override": "17.1.2",
         "@codingame/monaco-vscode-environment-service-override": "17.1.2",
@@ -669,6 +729,7 @@
       "version": "17.1.2",
       "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-b1e8558d-1726-5299-bc75-e43ee6d1a124-common/-/monaco-vscode-b1e8558d-1726-5299-bc75-e43ee6d1a124-common-17.1.2.tgz",
       "integrity": "sha512-vOBBWMx3kB9HXTH4c5DzqO7VpW1zz7T9miMc+gaZ3brLPAV4xJH3hWhR9dxDJus8bt989r6J807/GfKwM0UzRA==",
+      "license": "MIT",
       "dependencies": {
         "@codingame/monaco-vscode-5945a5e2-a66c-5a82-bd2c-1965724b29eb-common": "17.1.2",
         "@codingame/monaco-vscode-86d65fc6-30f9-5dca-9501-e249de688591-common": "17.1.2",
@@ -682,6 +743,7 @@
       "version": "17.1.2",
       "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-b4efa70b-52b9-5670-ab5c-f10b10b6834e-common/-/monaco-vscode-b4efa70b-52b9-5670-ab5c-f10b10b6834e-common-17.1.2.tgz",
       "integrity": "sha512-D+rriYX2cXwnN8vWnelV8vE+2nM4XA1U3Y0O2G6F4ufyU7NGkR+ADWsGSSEhlu17Plce9e+niRbHwqd5rOn62A==",
+      "license": "MIT",
       "dependencies": {
         "@codingame/monaco-vscode-api": "17.1.2"
       }
@@ -690,6 +752,7 @@
       "version": "17.1.2",
       "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-base-service-override/-/monaco-vscode-base-service-override-17.1.2.tgz",
       "integrity": "sha512-TjDHEdSw2CrO3fLPpOhyw9JTBVQArf8yGiS5YvAIBLUqpjyFej0AxUs2npXiRSAjDqv1PaxPNERbZHx4FXqMVw==",
+      "license": "MIT",
       "dependencies": {
         "@codingame/monaco-vscode-2cbab29e-9393-5de6-b701-9a9555360b6b-common": "17.1.2",
         "@codingame/monaco-vscode-34a0ffd3-b9f5-5699-b43b-38af5732f38a-common": "17.1.2",
@@ -705,6 +768,7 @@
       "version": "17.1.2",
       "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-bba55be6-41a2-50cd-a3cc-8bafa35bfa89-common/-/monaco-vscode-bba55be6-41a2-50cd-a3cc-8bafa35bfa89-common-17.1.2.tgz",
       "integrity": "sha512-3Qkjwak4mmJr9YWwWaX92b7RApJhrX5bl1fd4ehtTTZ2vYo8GN4sbed/s+neUlSNNTTirgvJoFfhWEmrxIbaeA==",
+      "license": "MIT",
       "dependencies": {
         "@codingame/monaco-vscode-324f9a6e-6231-5bfc-af17-e147abd2dfd2-common": "17.1.2",
         "@codingame/monaco-vscode-86d65fc6-30f9-5dca-9501-e249de688591-common": "17.1.2",
@@ -716,6 +780,7 @@
       "version": "17.1.2",
       "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-be8ddbb5-094a-5657-b1cc-fe106c94c632-common/-/monaco-vscode-be8ddbb5-094a-5657-b1cc-fe106c94c632-common-17.1.2.tgz",
       "integrity": "sha512-gfPRzQAjZHeWhBen7U65iNgdPiVkwrE7xYf8HUPq7ZFewvCoDMPiirwtMuF4mAhkxlADRS/uAgeuRdKGdO/nSw==",
+      "license": "MIT",
       "dependencies": {
         "@codingame/monaco-vscode-api": "17.1.2"
       }
@@ -724,6 +789,7 @@
       "version": "17.1.2",
       "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-bed2b49f-41ae-5ed2-b61a-1105500a3f8a-common/-/monaco-vscode-bed2b49f-41ae-5ed2-b61a-1105500a3f8a-common-17.1.2.tgz",
       "integrity": "sha512-JekYJxngPxV4QbvKrtZ8zRkTOqnUaAqDc8+mhsU8me6g8+hjfAExnyejBmFMAb5qfDMj4k3y9ap0QALXPM9+SA==",
+      "license": "MIT",
       "dependencies": {
         "@codingame/monaco-vscode-api": "17.1.2"
       }
@@ -732,6 +798,7 @@
       "version": "17.1.2",
       "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-bf94ddb5-e436-506a-9763-5ab86b642508-common/-/monaco-vscode-bf94ddb5-e436-506a-9763-5ab86b642508-common-17.1.2.tgz",
       "integrity": "sha512-41scluuTjLjB8OVtndn9kvU0RfNhPjp2sXqRU1Dn4O4z72saW4EYuIvOJXRBiydgqyar4c+tFO2RC+taQAXePg==",
+      "license": "MIT",
       "dependencies": {
         "@codingame/monaco-vscode-api": "17.1.2"
       }
@@ -740,6 +807,7 @@
       "version": "17.1.2",
       "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-bulk-edit-service-override/-/monaco-vscode-bulk-edit-service-override-17.1.2.tgz",
       "integrity": "sha512-TLBfxYjANEu2LKm8wiA4BejWI1eg0ti4svQB6XXTFOCohZnNub1tIpqTPiOvmk8dors/cggTM+ftz2TPdXTTgQ==",
+      "license": "MIT",
       "dependencies": {
         "@codingame/monaco-vscode-324f9a6e-6231-5bfc-af17-e147abd2dfd2-common": "17.1.2",
         "@codingame/monaco-vscode-65619f8f-0eab-5d8b-855a-43b6353fe527-common": "17.1.2",
@@ -752,6 +820,7 @@
       "version": "17.1.2",
       "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-c3c61c00-c254-5856-9dc9-d7929c1f9062-common/-/monaco-vscode-c3c61c00-c254-5856-9dc9-d7929c1f9062-common-17.1.2.tgz",
       "integrity": "sha512-RlJzR+gI59YOFb1Na+AmL6FNd6j/yJw1LUVgNERSLvgpBjEepO3lPua28vDNYiX1zdiVDs7rvv2gQIIPAzmZGw==",
+      "license": "MIT",
       "dependencies": {
         "@codingame/monaco-vscode-65619f8f-0eab-5d8b-855a-43b6353fe527-common": "17.1.2",
         "@codingame/monaco-vscode-86d65fc6-30f9-5dca-9501-e249de688591-common": "17.1.2",
@@ -768,6 +837,7 @@
       "version": "17.1.2",
       "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-c465110a-57c0-59d7-a6b2-be0a4db7e517-common/-/monaco-vscode-c465110a-57c0-59d7-a6b2-be0a4db7e517-common-17.1.2.tgz",
       "integrity": "sha512-2ub5bQiCDbxoYhzJNbGLFdvizJWRCtCzo9QNgkDG2m3wl9wQuM1R0xJ0HpGpUz3sJ1K7+aIoNwVDl0JaCBhJTg==",
+      "license": "MIT",
       "dependencies": {
         "@codingame/monaco-vscode-1ba786a5-b7d7-5d26-8a85-ae48ee2a74a4-common": "17.1.2",
         "@codingame/monaco-vscode-324f9a6e-6231-5bfc-af17-e147abd2dfd2-common": "17.1.2",
@@ -787,6 +857,7 @@
       "version": "17.1.2",
       "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-c8227507-8e59-53d6-b50b-71c0ab384cf4-common/-/monaco-vscode-c8227507-8e59-53d6-b50b-71c0ab384cf4-common-17.1.2.tgz",
       "integrity": "sha512-HXXqGa87kvvLzQdBoqcMui6QWad1/f/8s8f01PD0XjkVisJi9pP2GI09cKtzqB6KV5Bnpi6HSFZ4dsiPH9zP3A==",
+      "license": "MIT",
       "dependencies": {
         "@codingame/monaco-vscode-api": "17.1.2"
       }
@@ -795,6 +866,7 @@
       "version": "17.1.2",
       "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-cea4d01f-6526-5c2f-8b09-b168fead499f-common/-/monaco-vscode-cea4d01f-6526-5c2f-8b09-b168fead499f-common-17.1.2.tgz",
       "integrity": "sha512-mSbXySNi4nNEECgdPh0e998Qnn9GZHjamzTzIp9i1xPq/G1JVCvKtWUHyEOy7jZnJV5kgoo7UetMcBoSgsSGzQ==",
+      "license": "MIT",
       "dependencies": {
         "@codingame/monaco-vscode-api": "17.1.2"
       }
@@ -803,6 +875,7 @@
       "version": "17.1.2",
       "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-configuration-service-override/-/monaco-vscode-configuration-service-override-17.1.2.tgz",
       "integrity": "sha512-Rk95XpDSh7Zu4d6O+xXlXOo2U9VlqRYSaZTgM9mFUduk7TMiIP5Z8m/vUWwn0B1tGZHiCl1gbxs94vXfizXb5A==",
+      "license": "MIT",
       "dependencies": {
         "@codingame/monaco-vscode-2cbab29e-9393-5de6-b701-9a9555360b6b-common": "17.1.2",
         "@codingame/monaco-vscode-407531d3-fdae-5387-8c41-49ba0e9574b5-common": "17.1.2",
@@ -818,6 +891,7 @@
       "version": "17.1.2",
       "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-d0fb86d3-2a47-594e-955b-9a24631a7124-common/-/monaco-vscode-d0fb86d3-2a47-594e-955b-9a24631a7124-common-17.1.2.tgz",
       "integrity": "sha512-gb8Urgz/nlb6E0O1mR07Ek1a9s37WmlIIovqicOd4Iqep3eVOkEKqyNaXFl0BX0ed6wEE2PWh+PFAIj5Gp/vZw==",
+      "license": "MIT",
       "dependencies": {
         "@codingame/monaco-vscode-9c72783f-914c-50be-b9ef-da16356d81a8-common": "17.1.2",
         "@codingame/monaco-vscode-api": "17.1.2",
@@ -828,6 +902,7 @@
       "version": "17.1.2",
       "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-d26a96d3-122c-5a3d-a04d-deb5ff0f19c0-common/-/monaco-vscode-d26a96d3-122c-5a3d-a04d-deb5ff0f19c0-common-17.1.2.tgz",
       "integrity": "sha512-I5hk2NOiLbMIzTrjztjGIGm5lmqCEFq0WwNiQbrr4ZIeriqe+EK4pzclC/cIhov0c75KJB4XOHKxs7iIrfvh2A==",
+      "license": "MIT",
       "dependencies": {
         "@codingame/monaco-vscode-2a94c04a-b85b-5669-b06b-89c1bfa11cb9-common": "17.1.2",
         "@codingame/monaco-vscode-9efc1f50-c7de-55d6-8b28-bcc88bd49b5a-common": "17.1.2",
@@ -839,6 +914,7 @@
       "version": "17.1.2",
       "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-d481a59e-259c-524e-bee1-76483d75d3a1-common/-/monaco-vscode-d481a59e-259c-524e-bee1-76483d75d3a1-common-17.1.2.tgz",
       "integrity": "sha512-kOnIqlXEOSAozpmUjtGGYgilnCtWMkexB4irmHN2QaIze6DiBUkb35VmUs2Pys4GW3YAWlUZslhi6SjhgssdGg==",
+      "license": "MIT",
       "dependencies": {
         "@codingame/monaco-vscode-523730aa-81e6-55d7-9916-87ad537fe087-common": "17.1.2",
         "@codingame/monaco-vscode-5945a5e2-a66c-5a82-bd2c-1965724b29eb-common": "17.1.2",
@@ -855,6 +931,7 @@
       "version": "17.1.2",
       "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-d609a7d3-bf87-551a-884f-550a8b327ec5-common/-/monaco-vscode-d609a7d3-bf87-551a-884f-550a8b327ec5-common-17.1.2.tgz",
       "integrity": "sha512-pugciBX+Tjag/jPgiRgzJFBD25XVkvCRSxhkp8zp3W4W0eDCyr8o674sQ36cgKwff8tOUB2hGj7EtFz7GDEz/Q==",
+      "license": "MIT",
       "dependencies": {
         "@codingame/monaco-vscode-api": "17.1.2",
         "@codingame/monaco-vscode-c8227507-8e59-53d6-b50b-71c0ab384cf4-common": "17.1.2"
@@ -864,6 +941,7 @@
       "version": "17.1.2",
       "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-d7f659f5-da33-5ea8-a3b8-9b94f2cf5f33-common/-/monaco-vscode-d7f659f5-da33-5ea8-a3b8-9b94f2cf5f33-common-17.1.2.tgz",
       "integrity": "sha512-TDGNBPYrStSYDkn7qF10qLeX8WqDlksRzcibCM34i2gXL9Xkiet87aOwJk2TPoy47HZ1NsZGFo77MslMxGekiQ==",
+      "license": "MIT",
       "dependencies": {
         "@codingame/monaco-vscode-2cbab29e-9393-5de6-b701-9a9555360b6b-common": "17.1.2",
         "@codingame/monaco-vscode-a2719803-af40-5ae9-a29f-8a2231c33056-common": "17.1.2",
@@ -874,12 +952,14 @@
     "node_modules/@codingame/monaco-vscode-d987325e-3e05-53aa-b9ff-6f97476f64db-common": {
       "version": "17.1.2",
       "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-d987325e-3e05-53aa-b9ff-6f97476f64db-common/-/monaco-vscode-d987325e-3e05-53aa-b9ff-6f97476f64db-common-17.1.2.tgz",
-      "integrity": "sha512-M9foqW+zoTNBKxXUmgL4ARMTk2jLgVepsZdJGa7c17c+mdwEqlaF97bOvZ5+dLBLqdYdJME8fmmNz7l/+he++A=="
+      "integrity": "sha512-M9foqW+zoTNBKxXUmgL4ARMTk2jLgVepsZdJGa7c17c+mdwEqlaF97bOvZ5+dLBLqdYdJME8fmmNz7l/+he++A==",
+      "license": "MIT"
     },
     "node_modules/@codingame/monaco-vscode-e28ac690-06d5-5ee9-92d1-02df70296354-common": {
       "version": "17.1.2",
       "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-e28ac690-06d5-5ee9-92d1-02df70296354-common/-/monaco-vscode-e28ac690-06d5-5ee9-92d1-02df70296354-common-17.1.2.tgz",
       "integrity": "sha512-HEVpMPlu+yg1konUiigyC55hULmpCNh95z/D9i8XS5OvhyNT7H+lVJ5Bn5NP7h7Co8nU9IwrepI4LwP+kBy8aQ==",
+      "license": "MIT",
       "dependencies": {
         "@codingame/monaco-vscode-324f9a6e-6231-5bfc-af17-e147abd2dfd2-common": "17.1.2",
         "@codingame/monaco-vscode-407531d3-fdae-5387-8c41-49ba0e9574b5-common": "17.1.2",
@@ -897,12 +977,14 @@
     "node_modules/@codingame/monaco-vscode-e59ecb8c-db32-5324-8fe4-cf9921fd92b8-common": {
       "version": "17.1.2",
       "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-e59ecb8c-db32-5324-8fe4-cf9921fd92b8-common/-/monaco-vscode-e59ecb8c-db32-5324-8fe4-cf9921fd92b8-common-17.1.2.tgz",
-      "integrity": "sha512-FH47MrChoIfUwjQcmeIOnR934AtnqgKmLfd29/XUR3NuhhkNM29bhKFS8kWzpIL1dTZheBLJz13Kc63IejB2kg=="
+      "integrity": "sha512-FH47MrChoIfUwjQcmeIOnR934AtnqgKmLfd29/XUR3NuhhkNM29bhKFS8kWzpIL1dTZheBLJz13Kc63IejB2kg==",
+      "license": "MIT"
     },
     "node_modules/@codingame/monaco-vscode-e67a0dae-5b2c-54e6-8d61-90102c78362d-common": {
       "version": "17.1.2",
       "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-e67a0dae-5b2c-54e6-8d61-90102c78362d-common/-/monaco-vscode-e67a0dae-5b2c-54e6-8d61-90102c78362d-common-17.1.2.tgz",
       "integrity": "sha512-qqGyKnIy6ECbi9qxv7Ow/s9h9GNIQstFYayGx11hVRi3BsDOqZ6tKtKPf3vHVK57oUuxMkz1ps8gsqlDb9TLag==",
+      "license": "MIT",
       "dependencies": {
         "@codingame/monaco-vscode-65619f8f-0eab-5d8b-855a-43b6353fe527-common": "17.1.2",
         "@codingame/monaco-vscode-api": "17.1.2",
@@ -913,6 +995,7 @@
       "version": "17.1.2",
       "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-e72c94ca-257a-5b75-8b68-5a5fa3c18255-common/-/monaco-vscode-e72c94ca-257a-5b75-8b68-5a5fa3c18255-common-17.1.2.tgz",
       "integrity": "sha512-OCc252MKE1SJ1vxic1mYmjfCsipv4/YW6mzoFmP8DHbzlACBdC34LBAdUClXFAsLX2XFSUjM/DXszr6BpE4Eew==",
+      "license": "MIT",
       "dependencies": {
         "@codingame/monaco-vscode-407531d3-fdae-5387-8c41-49ba0e9574b5-common": "17.1.2",
         "@codingame/monaco-vscode-api": "17.1.2",
@@ -923,6 +1006,7 @@
       "version": "17.1.2",
       "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-ea14e352-8f1c-5569-b79a-8a96a53e8abe-common/-/monaco-vscode-ea14e352-8f1c-5569-b79a-8a96a53e8abe-common-17.1.2.tgz",
       "integrity": "sha512-KyEj8yK9cjEX8ZavSSu+kU4nIaM/AVRZh+uSojEg8cQMhGzP56ZBkU8I3JWgRifIYHTjVp8T0CmULHw9OjG6Cg==",
+      "license": "MIT",
       "dependencies": {
         "@codingame/monaco-vscode-api": "17.1.2",
         "@codingame/monaco-vscode-bed2b49f-41ae-5ed2-b61a-1105500a3f8a-common": "17.1.2",
@@ -933,6 +1017,7 @@
       "version": "17.1.2",
       "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-eb7d5efd-2e60-59f8-9ba4-9a8ae8cb2957-common/-/monaco-vscode-eb7d5efd-2e60-59f8-9ba4-9a8ae8cb2957-common-17.1.2.tgz",
       "integrity": "sha512-5D6djUTSEBDQLgjRsFgd7dRb1wDczuQEkd92eJdt7mkt/a3gYzTR/K46/yiEnWmq+qm5aN7Fn76GW7sQ697VDw==",
+      "license": "MIT",
       "dependencies": {
         "@codingame/monaco-vscode-65619f8f-0eab-5d8b-855a-43b6353fe527-common": "17.1.2",
         "@codingame/monaco-vscode-9ee79c1a-3f03-568b-8eac-b02513a98b68-common": "17.1.2",
@@ -946,6 +1031,7 @@
       "version": "17.1.2",
       "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-eba0b9b3-174c-5dae-9867-a37810ca1808-common/-/monaco-vscode-eba0b9b3-174c-5dae-9867-a37810ca1808-common-17.1.2.tgz",
       "integrity": "sha512-OcHc/zza0vqaRTSHuQBxxOSqP7uSD0YRxUABHUA3KIt8Z6j8Pz72L4s1WhIpZDYf+UOLnjIVTX/cNkyRDo01aA==",
+      "license": "MIT",
       "dependencies": {
         "@codingame/monaco-vscode-324f9a6e-6231-5bfc-af17-e147abd2dfd2-common": "17.1.2",
         "@codingame/monaco-vscode-api": "17.1.2"
@@ -955,6 +1041,7 @@
       "version": "17.1.2",
       "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-ecf3436d-6064-5fbd-a760-37a211ce79c7-common/-/monaco-vscode-ecf3436d-6064-5fbd-a760-37a211ce79c7-common-17.1.2.tgz",
       "integrity": "sha512-B04FjhB6UeAr//mUJGuv/GtHecFP08Wb0vLa4xO9bTqrUMXgePKjG1c8YKFR6lQODY+GNBtbsjCT53lqsTKWuQ==",
+      "license": "MIT",
       "dependencies": {
         "@codingame/monaco-vscode-2cbab29e-9393-5de6-b701-9a9555360b6b-common": "17.1.2",
         "@codingame/monaco-vscode-65619f8f-0eab-5d8b-855a-43b6353fe527-common": "17.1.2",
@@ -969,6 +1056,7 @@
       "version": "17.1.2",
       "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-editor-api/-/monaco-vscode-editor-api-17.1.2.tgz",
       "integrity": "sha512-RohpdBq+PHVc+tdA9kuuiFK1tRrBsAQW1Rc4MjfcJEEF9PAkxdbM9ysXSrhbb0aan5aC9zrURUUshLzIVV1+Qg==",
+      "license": "MIT",
       "dependencies": {
         "@codingame/monaco-vscode-5452e2b7-9081-5f95-839b-4ab3544ce28f-common": "17.1.2",
         "@codingame/monaco-vscode-api": "17.1.2"
@@ -978,6 +1066,7 @@
       "version": "17.1.2",
       "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-editor-service-override/-/monaco-vscode-editor-service-override-17.1.2.tgz",
       "integrity": "sha512-+zUIKhCkzHI3wVO9qUh1xEBzLJkV5hyVHM5aCeS6rz0cPxwsYQJ+d9kqT5GzXHhWreSmD15mNVyyqgUHuVJFhQ==",
+      "license": "MIT",
       "dependencies": {
         "@codingame/monaco-vscode-5945a5e2-a66c-5a82-bd2c-1965724b29eb-common": "17.1.2",
         "@codingame/monaco-vscode-9efc1f50-c7de-55d6-8b28-bcc88bd49b5a-common": "17.1.2",
@@ -989,6 +1078,7 @@
       "version": "17.1.2",
       "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-environment-service-override/-/monaco-vscode-environment-service-override-17.1.2.tgz",
       "integrity": "sha512-D6yTxizidj1INGktbRFJ0uhbkIHOvkt33CdFZpkDx0RYRDxtb/0yVyUQARQiQRKj5pz/5Pd276K/T9TFo+cFNQ==",
+      "license": "MIT",
       "dependencies": {
         "@codingame/monaco-vscode-abed5a84-8a82-5f84-9412-88a736235bae-common": "17.1.2",
         "@codingame/monaco-vscode-api": "17.1.2"
@@ -998,6 +1088,7 @@
       "version": "17.1.2",
       "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-extension-api/-/monaco-vscode-extension-api-17.1.2.tgz",
       "integrity": "sha512-jo5iA5edcskc4M5f7mVwq+dL/pE24d7Kja/80VQbF6VPC0ounfQwTjgOb+bY3FTg6jaFL1Gj6qrgaM8tnW81eQ==",
+      "license": "MIT",
       "dependencies": {
         "@codingame/monaco-vscode-34a0ffd3-b9f5-5699-b43b-38af5732f38a-common": "17.1.2",
         "@codingame/monaco-vscode-4a3ac544-9a61-534c-88df-756262793ef7-common": "17.1.2",
@@ -1009,6 +1100,7 @@
       "version": "17.1.2",
       "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-extensions-service-override/-/monaco-vscode-extensions-service-override-17.1.2.tgz",
       "integrity": "sha512-7x/Hs9vj1tS+y81FavegetSiJ3LTftcKWh5HvOEqxnuuN/GAmgDtqwoNGAfdiGzo3MAst1yDxE5iAqbJM6r9Ow==",
+      "license": "MIT",
       "dependencies": {
         "@codingame/monaco-vscode-0b087f42-a5a3-5eb9-9bfd-1eebc1bba163-common": "17.1.2",
         "@codingame/monaco-vscode-1cc4ea0a-c5b6-54ed-bb60-078a99119b55-common": "17.1.2",
@@ -1043,6 +1135,7 @@
       "version": "17.1.2",
       "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-f1bbc6d3-6129-583c-a2ba-c80b832993d2-common/-/monaco-vscode-f1bbc6d3-6129-583c-a2ba-c80b832993d2-common-17.1.2.tgz",
       "integrity": "sha512-YifpdenLJiMDxeJL86CzQiKOmUdMTAdmv7r2nVIfbDfq9Gco1eCdlXsBWWsjLfEQyPJbizQCA/JLuxXQ65LaPw==",
+      "license": "MIT",
       "dependencies": {
         "@codingame/monaco-vscode-api": "17.1.2"
       }
@@ -1051,6 +1144,7 @@
       "version": "17.1.2",
       "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-f22e7e55-aee8-5b52-a6bc-950efd9f5890-common/-/monaco-vscode-f22e7e55-aee8-5b52-a6bc-950efd9f5890-common-17.1.2.tgz",
       "integrity": "sha512-jsZ/5Ht+thsXqM2souEb7S7IhYSaDfAWWm6hpWlTkOTyKvAErunrhnbZyRC5vz8MnsvrFwDG/EMnq6VhNn9psA==",
+      "license": "MIT",
       "dependencies": {
         "@codingame/monaco-vscode-34a0ffd3-b9f5-5699-b43b-38af5732f38a-common": "17.1.2",
         "@codingame/monaco-vscode-a7c9ae3c-16d2-5d17-86b2-981be7094566-common": "17.1.2",
@@ -1062,6 +1156,7 @@
       "version": "17.1.2",
       "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-f48982c4-9e82-55e2-b800-20e6d1e6096f-common/-/monaco-vscode-f48982c4-9e82-55e2-b800-20e6d1e6096f-common-17.1.2.tgz",
       "integrity": "sha512-K3775Hh8Ly2vYKjg7Nv9KracmcmVZ++cpIhKj0eG5G2SAYB53oXBWe9Vkh4zCXl9oLDsMDMUZBi1SMNYZk+HVg==",
+      "license": "MIT",
       "dependencies": {
         "@codingame/monaco-vscode-95ea5c7c-15cf-50aa-8e24-38039b06b4a6-common": "17.1.2",
         "@codingame/monaco-vscode-9c72783f-914c-50be-b9ef-da16356d81a8-common": "17.1.2",
@@ -1073,6 +1168,7 @@
       "version": "17.1.2",
       "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-fab30422-b487-5f4e-8d30-8b4d266e3fcd-common/-/monaco-vscode-fab30422-b487-5f4e-8d30-8b4d266e3fcd-common-17.1.2.tgz",
       "integrity": "sha512-aNtSaZW1cWclvYBmwul7hz0w/ZAUk9Ty3qNc+VZt0+z5qtZ2dbdYsyg1zcFxuE7tTgtG0jJ+6Dx0IUFuDiBJqA==",
+      "license": "MIT",
       "dependencies": {
         "@codingame/monaco-vscode-0764a541-f621-5022-a1f8-cbdadacae5ec-common": "17.1.2",
         "@codingame/monaco-vscode-1cb11a73-359e-5a2f-9e95-6989cc9858ee-common": "17.1.2",
@@ -1093,6 +1189,7 @@
       "version": "17.1.2",
       "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-fc3b1755-9783-51f9-b3e6-45e7ef6fe6e3-common/-/monaco-vscode-fc3b1755-9783-51f9-b3e6-45e7ef6fe6e3-common-17.1.2.tgz",
       "integrity": "sha512-PlKwmoBVkaoG/5Q3ytJlaHq+i6edykY/OGMlHmlfeYJR79NxSb6m5xD9m8dbiovzO5Hp8bR6sal/v9A9MJ2YJA==",
+      "license": "MIT",
       "dependencies": {
         "@codingame/monaco-vscode-9c72783f-914c-50be-b9ef-da16356d81a8-common": "17.1.2",
         "@codingame/monaco-vscode-api": "17.1.2",
@@ -1105,6 +1202,7 @@
       "version": "17.1.2",
       "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-fc42f049-7883-579d-bb0b-2aa1010a19a8-common/-/monaco-vscode-fc42f049-7883-579d-bb0b-2aa1010a19a8-common-17.1.2.tgz",
       "integrity": "sha512-ouefz+q38GllD7i0zIfck+hXAsPssVImXZ0LcNVjxAZfaTeamxO8fswIgOBY5DfcfvO96UAnFLX/a109RdyCKw==",
+      "license": "MIT",
       "dependencies": {
         "@codingame/monaco-vscode-api": "17.1.2"
       }
@@ -1112,12 +1210,14 @@
     "node_modules/@codingame/monaco-vscode-ff9fa663-eae3-5274-8573-c2b918871e4b-common": {
       "version": "17.1.2",
       "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-ff9fa663-eae3-5274-8573-c2b918871e4b-common/-/monaco-vscode-ff9fa663-eae3-5274-8573-c2b918871e4b-common-17.1.2.tgz",
-      "integrity": "sha512-W61MCtJhoZouJCYCGfk5ucjBELhhSz3mEK2fI9EExF3U1ib5BhxlaHBdxsiw6UbONN1RcoafxIBBiq+kN3w1kQ=="
+      "integrity": "sha512-W61MCtJhoZouJCYCGfk5ucjBELhhSz3mEK2fI9EExF3U1ib5BhxlaHBdxsiw6UbONN1RcoafxIBBiq+kN3w1kQ==",
+      "license": "MIT"
     },
     "node_modules/@codingame/monaco-vscode-files-service-override": {
       "version": "17.1.2",
       "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-files-service-override/-/monaco-vscode-files-service-override-17.1.2.tgz",
       "integrity": "sha512-gybRtXQZr/WdKGv8ZSF9szGCzojqHpbD4oRhV+5NOwWTXL6tM7o/sHLhhlFIhtaUUpvZm7yYH3V3pMhzPeMVxg==",
+      "license": "MIT",
       "dependencies": {
         "@codingame/monaco-vscode-0c06bfba-d24d-5c4d-90cd-b40cefb7f811-common": "17.1.2",
         "@codingame/monaco-vscode-15626ec7-b165-51e1-8caf-7bcc2ae9b95a-common": "17.1.2",
@@ -1133,6 +1233,7 @@
       "version": "17.1.2",
       "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-host-service-override/-/monaco-vscode-host-service-override-17.1.2.tgz",
       "integrity": "sha512-Ne1NsPPjHqWRlZROExWhqO6rC21WqkXG8sBhcDOs/qbcvHNaAO59NXl1lgueaeQwXTU+9PKTzbakny4OAyBbjQ==",
+      "license": "MIT",
       "dependencies": {
         "@codingame/monaco-vscode-2cbab29e-9393-5de6-b701-9a9555360b6b-common": "17.1.2",
         "@codingame/monaco-vscode-34a0ffd3-b9f5-5699-b43b-38af5732f38a-common": "17.1.2",
@@ -1140,18 +1241,11 @@
         "@codingame/monaco-vscode-d0fb86d3-2a47-594e-955b-9a24631a7124-common": "17.1.2"
       }
     },
-    "node_modules/@codingame/monaco-vscode-json-default-extension": {
-      "version": "17.1.2",
-      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-json-default-extension/-/monaco-vscode-json-default-extension-17.1.2.tgz",
-      "integrity": "sha512-vdeZnFJ9Clt1SMdsEGgBVFeCCx+ZZOYrvumb4fdV1JOZA416BjXg2POoX6BEeDjerjnfI70kcHM1mqgivLpYGg==",
-      "dependencies": {
-        "@codingame/monaco-vscode-api": "17.1.2"
-      }
-    },
     "node_modules/@codingame/monaco-vscode-keybindings-service-override": {
       "version": "17.1.2",
       "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-keybindings-service-override/-/monaco-vscode-keybindings-service-override-17.1.2.tgz",
       "integrity": "sha512-cQHhlxjMSDqy/zNXVeCZ/WcX6/xSkNDqtHU90A88QRrMsRZD8m+VsbJrxLQtsmxzUREkyLubaLl/EeDbPCRd+A==",
+      "license": "MIT",
       "dependencies": {
         "@codingame/monaco-vscode-2a22c7b4-b906-5914-8cd1-3ed912fb738f-common": "17.1.2",
         "@codingame/monaco-vscode-2cbab29e-9393-5de6-b701-9a9555360b6b-common": "17.1.2",
@@ -1168,6 +1262,7 @@
       "version": "17.1.2",
       "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-language-pack-cs/-/monaco-vscode-language-pack-cs-17.1.2.tgz",
       "integrity": "sha512-VWKpaWq6QVAOZHrL8LSrkGfkVO1HiTi5oEXzB9hTzcNGrROPosE1r1LGUbTN+aHFWYaKteL6dn2g7VDfecXwuA==",
+      "license": "MIT",
       "dependencies": {
         "@codingame/monaco-vscode-api": "17.1.2"
       }
@@ -1176,6 +1271,7 @@
       "version": "17.1.2",
       "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-language-pack-de/-/monaco-vscode-language-pack-de-17.1.2.tgz",
       "integrity": "sha512-bwfIRGSMPvV9K9q5Q291mi3lzrHlJ3J1e25btpm21kPhRgkQBhncPo2V3FpTILEjWG53Lt4dvbpS1B/Ll9Eq5A==",
+      "license": "MIT",
       "dependencies": {
         "@codingame/monaco-vscode-api": "17.1.2"
       }
@@ -1184,6 +1280,7 @@
       "version": "17.1.2",
       "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-language-pack-es/-/monaco-vscode-language-pack-es-17.1.2.tgz",
       "integrity": "sha512-LXar6XxrYfPvVW9lbj3gl2FHVwkldzvMmVR+PKAdhhqRl8pOvRM1bppSm81nI+33DL0UNvAnRLLVo8gyeLOK/g==",
+      "license": "MIT",
       "dependencies": {
         "@codingame/monaco-vscode-api": "17.1.2"
       }
@@ -1192,6 +1289,7 @@
       "version": "17.1.2",
       "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-language-pack-fr/-/monaco-vscode-language-pack-fr-17.1.2.tgz",
       "integrity": "sha512-vW0AfvusrbYNYoKQktPhht4r5dq3Hog0/cjKJdUv62AjsWbv2MZv85QiOkHAZQHHM0s9ioFoniFyCZme+7+XYg==",
+      "license": "MIT",
       "dependencies": {
         "@codingame/monaco-vscode-api": "17.1.2"
       }
@@ -1200,6 +1298,7 @@
       "version": "17.1.2",
       "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-language-pack-it/-/monaco-vscode-language-pack-it-17.1.2.tgz",
       "integrity": "sha512-VM+tL3eB4rDJAvDVsvvzxVtFizqCkaWu20Etl/1yT24//pXISlYb2bNTI1971kFIB9ifpTQnlbFj3d/oU1Z+/Q==",
+      "license": "MIT",
       "dependencies": {
         "@codingame/monaco-vscode-api": "17.1.2"
       }
@@ -1208,6 +1307,7 @@
       "version": "17.1.2",
       "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-language-pack-ja/-/monaco-vscode-language-pack-ja-17.1.2.tgz",
       "integrity": "sha512-uacF4GfkGhSaBAiIYYBcDJfrN16oVm+M3OyPgsakLYISayOMZRXvSREN1OrU7b6bx1N9jh7uuTQuuyckUupApA==",
+      "license": "MIT",
       "dependencies": {
         "@codingame/monaco-vscode-api": "17.1.2"
       }
@@ -1216,6 +1316,7 @@
       "version": "17.1.2",
       "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-language-pack-ko/-/monaco-vscode-language-pack-ko-17.1.2.tgz",
       "integrity": "sha512-aj3BRcbX3G+76A27LOlU8hRrFYllGgnC2Q4CnVzY5Gd8/V0FTO8Zn5Nrx0xLWebQrTTaHi5XyNZYmxngMbJgQg==",
+      "license": "MIT",
       "dependencies": {
         "@codingame/monaco-vscode-api": "17.1.2"
       }
@@ -1224,6 +1325,7 @@
       "version": "17.1.2",
       "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-language-pack-pl/-/monaco-vscode-language-pack-pl-17.1.2.tgz",
       "integrity": "sha512-IzQP5pechgtX3UBbOBWkTaOYAx0AHCnvO55bz0HL/ymlkVGdCoK1s7f/ylqjrLs2DcibgPiP/+LmGZo3s+ROrw==",
+      "license": "MIT",
       "dependencies": {
         "@codingame/monaco-vscode-api": "17.1.2"
       }
@@ -1232,6 +1334,7 @@
       "version": "17.1.2",
       "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-language-pack-pt-br/-/monaco-vscode-language-pack-pt-br-17.1.2.tgz",
       "integrity": "sha512-NipPs9hDdMP/JsbHGJCiroEcF841fc1Q3ZYKWaagjW+rS7ladsEx3XgeLW0XdeasI0LoKjYB/3sIfrDvXvNGbw==",
+      "license": "MIT",
       "dependencies": {
         "@codingame/monaco-vscode-api": "17.1.2"
       }
@@ -1240,6 +1343,7 @@
       "version": "17.1.2",
       "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-language-pack-qps-ploc/-/monaco-vscode-language-pack-qps-ploc-17.1.2.tgz",
       "integrity": "sha512-x2FGZBAX1cTSdO6FW8+vpCk6GoK2KwtUpiwNPdmHsjvTWF4QnjMZJHSmHTgtnVJ2XTcpoaFeS5mSLNsEJQoAGg==",
+      "license": "MIT",
       "dependencies": {
         "@codingame/monaco-vscode-api": "17.1.2"
       }
@@ -1248,6 +1352,7 @@
       "version": "17.1.2",
       "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-language-pack-ru/-/monaco-vscode-language-pack-ru-17.1.2.tgz",
       "integrity": "sha512-S0atr1JlrVd9AWQm2WpgQ7PbbQtwBq2AOviSltCiz1lNvZWmiAmIykIaN1v/MlflGL0YGfiZS/M8tXyoVFs37w==",
+      "license": "MIT",
       "dependencies": {
         "@codingame/monaco-vscode-api": "17.1.2"
       }
@@ -1256,6 +1361,7 @@
       "version": "17.1.2",
       "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-language-pack-tr/-/monaco-vscode-language-pack-tr-17.1.2.tgz",
       "integrity": "sha512-vOcLMMMdOxDsMGvtkY7AJmGnKqcxcEEl/dasi/d2a5zIUGzpSkASNITjYmWTy9DuIFi4E8XBbaC7+6iCKcQwIw==",
+      "license": "MIT",
       "dependencies": {
         "@codingame/monaco-vscode-api": "17.1.2"
       }
@@ -1264,6 +1370,7 @@
       "version": "17.1.2",
       "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-language-pack-zh-hans/-/monaco-vscode-language-pack-zh-hans-17.1.2.tgz",
       "integrity": "sha512-qGCrSVrgW6M3Wshf3ffaIInPh4ljHHt96/Z9bDk/gIifGH4cEcO8iQC2y7gSR4Vb0BbDwR+9Zw2Rw9dccCZdZg==",
+      "license": "MIT",
       "dependencies": {
         "@codingame/monaco-vscode-api": "17.1.2"
       }
@@ -1272,6 +1379,7 @@
       "version": "17.1.2",
       "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-language-pack-zh-hant/-/monaco-vscode-language-pack-zh-hant-17.1.2.tgz",
       "integrity": "sha512-qrGcAGwC4QVeKk4qofS8PbeEh35UgW7/Gpr0vvIYqvElXCkwZN1Wq4lBlXVLU6Q1S4VvncKoaaPiUV7pDAF5QA==",
+      "license": "MIT",
       "dependencies": {
         "@codingame/monaco-vscode-api": "17.1.2"
       }
@@ -1280,6 +1388,7 @@
       "version": "17.1.2",
       "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-languages-service-override/-/monaco-vscode-languages-service-override-17.1.2.tgz",
       "integrity": "sha512-bXHl0EreiDGYJ3NnFIxtxiCQx0Dp6xGrCZM70XbgrFHEpkiWEQJixluhR6EHBqvKUhn5gKvlKN3ZV0W0lsHvVA==",
+      "license": "MIT",
       "dependencies": {
         "@codingame/monaco-vscode-api": "17.1.2",
         "@codingame/monaco-vscode-files-service-override": "17.1.2"
@@ -1289,6 +1398,7 @@
       "version": "17.1.2",
       "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-layout-service-override/-/monaco-vscode-layout-service-override-17.1.2.tgz",
       "integrity": "sha512-fsWH0pk9D432Ss71Yps5wAGU3aK0/oDhso2PmobvxSnNiXKM50b3jmPNpVLf2aoAIqdWQzkoBJ1WmXDxZoxseg==",
+      "license": "MIT",
       "dependencies": {
         "@codingame/monaco-vscode-6bf85d7b-e6e3-54e9-9bc1-7e08d663f0f6-common": "17.1.2",
         "@codingame/monaco-vscode-85886bdb-61c5-52f1-8eb7-d1d32f6f8cbd-common": "17.1.2",
@@ -1300,6 +1410,7 @@
       "version": "17.1.2",
       "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-localization-service-override/-/monaco-vscode-localization-service-override-17.1.2.tgz",
       "integrity": "sha512-rE6pKeQpiEvs0m8vl8ft519H5EKEuaeTqgoq4mxST9vz3ip2llhlpuXeJSevYSqeqtVEnspgQpAza3atXvcEdw==",
+      "license": "MIT",
       "dependencies": {
         "@codingame/monaco-vscode-912ff6c1-e6aa-58cf-bd7f-50cf27bdb591-common": "17.1.2",
         "@codingame/monaco-vscode-api": "17.1.2"
@@ -1309,6 +1420,7 @@
       "version": "17.1.2",
       "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-log-service-override/-/monaco-vscode-log-service-override-17.1.2.tgz",
       "integrity": "sha512-61c8+aKtP1hHPnxlDgOlEEf77k3CKeRh50Of0+l7zDhJqBjvEu5L92tnFOGK4phnEkee6I36f36+RCtz2kVycQ==",
+      "license": "MIT",
       "dependencies": {
         "@codingame/monaco-vscode-abed5a84-8a82-5f84-9412-88a736235bae-common": "17.1.2",
         "@codingame/monaco-vscode-api": "17.1.2",
@@ -1320,6 +1432,7 @@
       "version": "17.1.2",
       "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-model-service-override/-/monaco-vscode-model-service-override-17.1.2.tgz",
       "integrity": "sha512-6oUn9qfGr/ET19lx2QhIoxktt0iWZ25wLPRhr+IitJrOXWVkY323HcQNgzCIkxQHR/WZccds8gsgeV5q2EI83A==",
+      "license": "MIT",
       "dependencies": {
         "@codingame/monaco-vscode-0c06bfba-d24d-5c4d-90cd-b40cefb7f811-common": "17.1.2",
         "@codingame/monaco-vscode-86d65fc6-30f9-5dca-9501-e249de688591-common": "17.1.2",
@@ -1330,6 +1443,7 @@
       "version": "17.1.2",
       "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-monarch-service-override/-/monaco-vscode-monarch-service-override-17.1.2.tgz",
       "integrity": "sha512-Ufj789U8FcF593A6PFpkHuDI1x2et2e6geu/yNOgzwue15rp4bRz4Bt1Hz2GXXh0U2OABaXJZgM5UFxHtjSMnw==",
+      "license": "MIT",
       "dependencies": {
         "@codingame/monaco-vscode-api": "17.1.2"
       }
@@ -1338,6 +1452,7 @@
       "version": "17.1.2",
       "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-quickaccess-service-override/-/monaco-vscode-quickaccess-service-override-17.1.2.tgz",
       "integrity": "sha512-g24QJmr7k7R2Q7fERGtsjYbC2nNijrtyy/YU+R7kI26G1aaPH03hliEeUXx4svz2DtwIjfkEixdz6HJV4t3aRQ==",
+      "license": "MIT",
       "dependencies": {
         "@codingame/monaco-vscode-2cbab29e-9393-5de6-b701-9a9555360b6b-common": "17.1.2",
         "@codingame/monaco-vscode-34a0ffd3-b9f5-5699-b43b-38af5732f38a-common": "17.1.2",
@@ -1353,6 +1468,7 @@
       "version": "17.1.2",
       "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-rollup-vsix-plugin/-/monaco-vscode-rollup-vsix-plugin-17.1.2.tgz",
       "integrity": "sha512-uTnU6sIX8TjodD4LPsYMROshHO7m9I8uBePhqI32FZKuUluRoE/vNoncPjpW0+m3yczNpRpIk2I7mbGguZXLCA==",
+      "license": "MIT",
       "dependencies": {
         "@rollup/pluginutils": "^5.1.4",
         "css-url-parser": "^1.1.4",
@@ -1362,10 +1478,20 @@
         "yauzl": "^3.0.0"
       }
     },
+    "node_modules/@codingame/monaco-vscode-standalone-languages": {
+      "version": "17.1.2",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-standalone-languages/-/monaco-vscode-standalone-languages-17.1.2.tgz",
+      "integrity": "sha512-6JUJ66t/r8J829SEChsdw+KkcyQEEl+bhnGEuhtj/WbSCwlcXw2FG59J2HRWK7R+pPN+3Jpj8s1BK8SmYUsb3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "monaco-editor": "npm:@codingame/monaco-vscode-editor-api@17.1.2"
+      }
+    },
     "node_modules/@codingame/monaco-vscode-textmate-service-override": {
       "version": "17.1.2",
       "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-textmate-service-override/-/monaco-vscode-textmate-service-override-17.1.2.tgz",
       "integrity": "sha512-4rHvKEIE44mhs/NMB1ikkLjJePXempxFGhxokGd9gxn0IC9pJgHeO//V7F7AyZXp4js2tgnGO5/xBHw34AHmxw==",
+      "license": "MIT",
       "dependencies": {
         "@codingame/monaco-vscode-1ba786a5-b7d7-5d26-8a85-ae48ee2a74a4-common": "17.1.2",
         "@codingame/monaco-vscode-33833ac7-3af3-5e9d-8fb9-11838d852c59-common": "17.1.2",
@@ -1380,6 +1506,7 @@
       "version": "17.1.2",
       "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-theme-defaults-default-extension/-/monaco-vscode-theme-defaults-default-extension-17.1.2.tgz",
       "integrity": "sha512-8PERBP/65kdIMvuUVPtp6yuJytRpivYOK3afWsF4ZSpCSIl+TGeKv7W18UDK8WCUlkHcR/Miux6ckU2YTl1LBQ==",
+      "license": "MIT",
       "dependencies": {
         "@codingame/monaco-vscode-api": "17.1.2"
       }
@@ -1388,6 +1515,7 @@
       "version": "17.1.2",
       "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-theme-service-override/-/monaco-vscode-theme-service-override-17.1.2.tgz",
       "integrity": "sha512-2Wm5Wg7ElodCkFa03aMhlcrLFY1j7qAxcUiVA1qXHh+hDsjFnG7DCkbgdM373ATT37aCWHZiNft9pjYhjzoPfg==",
+      "license": "MIT",
       "dependencies": {
         "@codingame/monaco-vscode-34a0ffd3-b9f5-5699-b43b-38af5732f38a-common": "17.1.2",
         "@codingame/monaco-vscode-7443a901-21f6-577a-9674-42893b997ee0-common": "17.1.2",
@@ -1400,6 +1528,7 @@
       "version": "17.1.2",
       "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-view-banner-service-override/-/monaco-vscode-view-banner-service-override-17.1.2.tgz",
       "integrity": "sha512-5A0bfOR7hncw6vaGsPajrsYYrKfiVjBYXIVCsflnIJnkvhH8S/F+XUjHdBdAPTcMxXFLVMkTXjrQ5ZZ1egGFcA==",
+      "license": "MIT",
       "dependencies": {
         "@codingame/monaco-vscode-34a0ffd3-b9f5-5699-b43b-38af5732f38a-common": "17.1.2",
         "@codingame/monaco-vscode-85886bdb-61c5-52f1-8eb7-d1d32f6f8cbd-common": "17.1.2",
@@ -1411,6 +1540,7 @@
       "version": "17.1.2",
       "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-view-common-service-override/-/monaco-vscode-view-common-service-override-17.1.2.tgz",
       "integrity": "sha512-jplCJyEK1kpBuMDAhAO/62noRKzoKH7Kwb1bG2rS/hJbukAFlmYUd9BYSITAHsXnR/Rjcr8fLW9krWJkX81SRw==",
+      "license": "MIT",
       "dependencies": {
         "@codingame/monaco-vscode-0c06bfba-d24d-5c4d-90cd-b40cefb7f811-common": "17.1.2",
         "@codingame/monaco-vscode-0cc5da60-f921-59b9-bd8c-a018e93c0a6f-common": "17.1.2",
@@ -1459,6 +1589,7 @@
       "version": "17.1.2",
       "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-view-status-bar-service-override/-/monaco-vscode-view-status-bar-service-override-17.1.2.tgz",
       "integrity": "sha512-uHQ126w8F+0NmugbeBp2fVcel9luya/AmuP2yozoUvh+hSRRUOPjkFGgQykumNr1b08uVs4lwKMCM+358d6Q7g==",
+      "license": "MIT",
       "dependencies": {
         "@codingame/monaco-vscode-0cc5da60-f921-59b9-bd8c-a018e93c0a6f-common": "17.1.2",
         "@codingame/monaco-vscode-85886bdb-61c5-52f1-8eb7-d1d32f6f8cbd-common": "17.1.2",
@@ -1471,6 +1602,7 @@
       "version": "17.1.2",
       "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-view-title-bar-service-override/-/monaco-vscode-view-title-bar-service-override-17.1.2.tgz",
       "integrity": "sha512-HNrRerVtwct8KTiIz7bVeycF/+zav3Bm6n/cj4lkAQxz6phgmoVLW5B/v9nlpaWZe00fpxBqn6HQocjRYtwHiw==",
+      "license": "MIT",
       "dependencies": {
         "@codingame/monaco-vscode-0764a541-f621-5022-a1f8-cbdadacae5ec-common": "17.1.2",
         "@codingame/monaco-vscode-34a0ffd3-b9f5-5699-b43b-38af5732f38a-common": "17.1.2",
@@ -1488,6 +1620,7 @@
       "version": "17.1.2",
       "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-views-service-override/-/monaco-vscode-views-service-override-17.1.2.tgz",
       "integrity": "sha512-bzIYy8uv/klg76W7/fAhVxnYHD7QuEs/jOlwMKvSxGco7ACeNxPJKM0sU4m54xDDdyuR1IlC1jyC70Je7W6KAg==",
+      "license": "MIT",
       "dependencies": {
         "@codingame/monaco-vscode-6980eeab-47bb-5a48-8e15-32caf0785565-common": "17.1.2",
         "@codingame/monaco-vscode-6bf85d7b-e6e3-54e9-9bc1-7e08d663f0f6-common": "17.1.2",
@@ -1508,6 +1641,7 @@
       "version": "17.1.2",
       "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-workbench-service-override/-/monaco-vscode-workbench-service-override-17.1.2.tgz",
       "integrity": "sha512-fxXuPYXZXYMAwN4DePtJz6NscmJ+sk+D9Q+KikMfKeTViFq3IBckoyyaKJeslzA2Ofwoev+7PgbGavWhjdruNA==",
+      "license": "MIT",
       "dependencies": {
         "@codingame/monaco-vscode-1021b67c-93e5-5c78-a270-cbdb2574d980-common": "17.1.2",
         "@codingame/monaco-vscode-256d5b78-0649-50e9-8354-2807f95f68f4-common": "17.1.2",
@@ -1538,6 +1672,7 @@
       "cpu": [
         "ppc64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "aix"
@@ -1553,6 +1688,7 @@
       "cpu": [
         "arm"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "android"
@@ -1568,6 +1704,7 @@
       "cpu": [
         "arm64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "android"
@@ -1583,6 +1720,7 @@
       "cpu": [
         "x64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "android"
@@ -1598,6 +1736,7 @@
       "cpu": [
         "arm64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
@@ -1613,6 +1752,7 @@
       "cpu": [
         "x64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
@@ -1628,6 +1768,7 @@
       "cpu": [
         "arm64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "freebsd"
@@ -1643,6 +1784,7 @@
       "cpu": [
         "x64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "freebsd"
@@ -1658,6 +1800,7 @@
       "cpu": [
         "arm"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -1673,6 +1816,7 @@
       "cpu": [
         "arm64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -1688,6 +1832,7 @@
       "cpu": [
         "ia32"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -1703,6 +1848,7 @@
       "cpu": [
         "loong64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -1718,6 +1864,7 @@
       "cpu": [
         "mips64el"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -1733,6 +1880,7 @@
       "cpu": [
         "ppc64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -1748,6 +1896,7 @@
       "cpu": [
         "riscv64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -1763,6 +1912,7 @@
       "cpu": [
         "s390x"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -1778,6 +1928,7 @@
       "cpu": [
         "x64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -1793,6 +1944,7 @@
       "cpu": [
         "arm64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "netbsd"
@@ -1808,6 +1960,7 @@
       "cpu": [
         "x64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "netbsd"
@@ -1823,6 +1976,7 @@
       "cpu": [
         "arm64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "openbsd"
@@ -1838,6 +1992,7 @@
       "cpu": [
         "x64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "openbsd"
@@ -1853,6 +2008,7 @@
       "cpu": [
         "x64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "sunos"
@@ -1868,6 +2024,7 @@
       "cpu": [
         "arm64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "win32"
@@ -1883,6 +2040,7 @@
       "cpu": [
         "ia32"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "win32"
@@ -1898,6 +2056,7 @@
       "cpu": [
         "x64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "win32"
@@ -1910,6 +2069,7 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@jsonjoy.com/base64/-/base64-1.1.2.tgz",
       "integrity": "sha512-q6XAnWQDIMA3+FTiOYajoYqySkO+JSat0ytXGSuRdq9uXE7o92gzuQwQM14xaCRlBLGq3v5miDGC4vkVTn54xA==",
+      "license": "Apache-2.0",
       "engines": {
         "node": ">=10.0"
       },
@@ -1925,6 +2085,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@jsonjoy.com/json-pack/-/json-pack-1.2.0.tgz",
       "integrity": "sha512-io1zEbbYcElht3tdlqEOFxZ0dMTYrHz9iMf0gqn1pPjZFTCgM5R4R5IMA20Chb2UPYYsxjzs8CgZ7Nb5n2K2rA==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@jsonjoy.com/base64": "^1.1.1",
         "@jsonjoy.com/util": "^1.1.2",
@@ -1946,6 +2107,7 @@
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/@jsonjoy.com/util/-/util-1.6.0.tgz",
       "integrity": "sha512-sw/RMbehRhN68WRtcKCpQOPfnH6lLP4GJfqzi3iYej8tnzpZUDr6UkZYJjcjjC0FWEJOJbyM3PTIwxucUmDG2A==",
+      "license": "Apache-2.0",
       "engines": {
         "node": ">=10.0"
       },
@@ -1961,6 +2123,7 @@
       "version": "5.1.4",
       "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.1.4.tgz",
       "integrity": "sha512-USm05zrsFxYLPdWWq+K3STlWiT/3ELn3RcV5hJMghpeAIhxfsUIg6mt12CBJBInWMV4VneoV7SfGv8xIwo2qNQ==",
+      "license": "MIT",
       "dependencies": {
         "@types/estree": "^1.0.0",
         "estree-walker": "^2.0.2",
@@ -1985,6 +2148,7 @@
       "cpu": [
         "arm"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "android"
@@ -1997,6 +2161,7 @@
       "cpu": [
         "arm64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "android"
@@ -2009,6 +2174,7 @@
       "cpu": [
         "arm64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
@@ -2021,6 +2187,7 @@
       "cpu": [
         "x64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
@@ -2033,6 +2200,7 @@
       "cpu": [
         "arm64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "freebsd"
@@ -2045,6 +2213,7 @@
       "cpu": [
         "x64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "freebsd"
@@ -2057,6 +2226,7 @@
       "cpu": [
         "arm"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -2069,6 +2239,7 @@
       "cpu": [
         "arm"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -2081,6 +2252,7 @@
       "cpu": [
         "arm64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -2093,6 +2265,7 @@
       "cpu": [
         "arm64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -2105,6 +2278,7 @@
       "cpu": [
         "loong64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -2117,6 +2291,7 @@
       "cpu": [
         "ppc64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -2129,6 +2304,7 @@
       "cpu": [
         "riscv64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -2141,6 +2317,7 @@
       "cpu": [
         "riscv64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -2153,6 +2330,7 @@
       "cpu": [
         "s390x"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -2165,6 +2343,7 @@
       "cpu": [
         "x64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -2177,6 +2356,7 @@
       "cpu": [
         "x64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -2189,6 +2369,7 @@
       "cpu": [
         "arm64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "win32"
@@ -2201,6 +2382,7 @@
       "cpu": [
         "ia32"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "win32"
@@ -2213,6 +2395,7 @@
       "cpu": [
         "x64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "win32"
@@ -2221,34 +2404,40 @@
     "node_modules/@types/estree": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.7.tgz",
-      "integrity": "sha512-w28IoSUCJpidD/TGviZwwMJckNESJZXFu7NBZ5YJ4mEUnNraUn9Pm8HSZm/jDF1pDWYKspWE7oVphigUPRakIQ=="
+      "integrity": "sha512-w28IoSUCJpidD/TGviZwwMJckNESJZXFu7NBZ5YJ4mEUnNraUn9Pm8HSZm/jDF1pDWYKspWE7oVphigUPRakIQ==",
+      "license": "MIT"
     },
     "node_modules/@types/trusted-types": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
       "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT",
       "optional": true
     },
     "node_modules/@types/vscode": {
       "version": "1.100.0",
       "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.100.0.tgz",
       "integrity": "sha512-4uNyvzHoraXEeCamR3+fzcBlh7Afs4Ifjs4epINyUX/jvdk0uzLnwiDY35UKDKnkCHP5Nu3dljl2H8lR6s+rQw==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@vscode/iconv-lite-umd": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/@vscode/iconv-lite-umd/-/iconv-lite-umd-0.7.0.tgz",
-      "integrity": "sha512-bRRFxLfg5dtAyl5XyiVWz/ZBPahpOpPrNYnnHpOpUZvam4tKH35wdhP4Kj6PbM0+KdliOsPzbGWpkxcdpNB/sg=="
+      "integrity": "sha512-bRRFxLfg5dtAyl5XyiVWz/ZBPahpOpPrNYnnHpOpUZvam4tKH35wdhP4Kj6PbM0+KdliOsPzbGWpkxcdpNB/sg==",
+      "license": "MIT"
     },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "license": "MIT"
     },
     "node_modules/brace-expansion": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
       "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
       }
@@ -2257,6 +2446,7 @@
       "version": "0.2.13",
       "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
       "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
+      "license": "MIT",
       "engines": {
         "node": "*"
       }
@@ -2264,12 +2454,14 @@
     "node_modules/css-url-parser": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/css-url-parser/-/css-url-parser-1.1.4.tgz",
-      "integrity": "sha512-gIpYB7ZqfIsd+/kJ8CE4pesAbIUEaZM+30Ylfl7rr0zJONslIchmi3utzY64qHIOhD/wXDrcSo7jU2VDqG7GiQ=="
+      "integrity": "sha512-gIpYB7ZqfIsd+/kJ8CE4pesAbIUEaZM+30Ylfl7rr0zJONslIchmi3utzY64qHIOhD/wXDrcSo7jU2VDqG7GiQ==",
+      "license": "MIT"
     },
     "node_modules/dompurify": {
       "version": "3.2.6",
       "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.2.6.tgz",
       "integrity": "sha512-/2GogDQlohXPZe6D6NOgQvXLPSYBqIWMnZ8zzOhn09REE4eyAzb+Hed3jhoM9OkuaJ8P6ZGTTVWQKAi8ieIzfQ==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"
       }
@@ -2279,6 +2471,7 @@
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.5.tgz",
       "integrity": "sha512-P8OtKZRv/5J5hhz0cUAdu/cLuPIKXpQl1R9pZtvmHWQvrAUVd0UNIPT4IB4W3rNOqVO0rlqHmCIbSwxh/c9yUQ==",
       "hasInstallScript": true,
+      "license": "MIT",
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -2316,12 +2509,14 @@
     "node_modules/estree-walker": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
-      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w=="
+      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+      "license": "MIT"
     },
     "node_modules/fdir": {
       "version": "6.4.5",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.4.5.tgz",
       "integrity": "sha512-4BG7puHpVsIYxZUbiUE3RqGloLaSSwzYie5jvasC4LWuBWzZawynvYouhjbQKw2JuIGYdm0DzIxl8iVidKlUEw==",
+      "license": "MIT",
       "peerDependencies": {
         "picomatch": "^3 || ^4"
       },
@@ -2336,6 +2531,7 @@
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
       "hasInstallScript": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
@@ -2348,6 +2544,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/hyperdyperid/-/hyperdyperid-1.2.0.tgz",
       "integrity": "sha512-Y93lCzHYgGWdrJ66yIktxiaGULYc6oGiABxhcO5AufBeOyoIdZF7bIfLaOrbM0iGIOXQQgxxRrFEnb+Y6w1n4A==",
+      "license": "MIT",
       "engines": {
         "node": ">=10.18"
       }
@@ -2356,6 +2553,7 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/import-meta-resolve/-/import-meta-resolve-4.1.0.tgz",
       "integrity": "sha512-I6fiaX09Xivtk+THaMfAwnA3MVA5Big1WHF1Dfx9hFuvNIWpXnorlkzhcQf6ehrqQiiZECRt1poOAkPmer3ruw==",
+      "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
@@ -2365,6 +2563,7 @@
       "version": "3.1.4",
       "resolved": "https://registry.npmjs.org/jschardet/-/jschardet-3.1.4.tgz",
       "integrity": "sha512-/kmVISmrwVwtyYU40iQUOp3SUPk2dhNCMsZBQX0R1/jZ8maaXJ/oZIzUOiyOqcgtLnETFKYChbJ5iDC/eWmFHg==",
+      "license": "LGPL-2.1+",
       "engines": {
         "node": ">=0.1.90"
       }
@@ -2373,6 +2572,7 @@
       "version": "14.0.0",
       "resolved": "https://registry.npmjs.org/marked/-/marked-14.0.0.tgz",
       "integrity": "sha512-uIj4+faQ+MgHgwUW1l2PsPglZLOLOT1uErt06dAPtx2kjteLAkbsd/0FiYg/MGS+i7ZKLb7w2WClxHkzOOuryQ==",
+      "license": "MIT",
       "bin": {
         "marked": "bin/marked.js"
       },
@@ -2384,6 +2584,7 @@
       "version": "4.17.2",
       "resolved": "https://registry.npmjs.org/memfs/-/memfs-4.17.2.tgz",
       "integrity": "sha512-NgYhCOWgovOXSzvYgUW0LQ7Qy72rWQMGGFJDoWg4G30RHd3z77VbYdtJ4fembJXBy8pMIUA31XNAupobOQlwdg==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@jsonjoy.com/json-pack": "^1.0.3",
         "@jsonjoy.com/util": "^1.3.0",
@@ -2402,6 +2603,7 @@
       "version": "1.54.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
       "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
       "engines": {
         "node": ">= 0.6"
       }
@@ -2410,6 +2612,7 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.1.tgz",
       "integrity": "sha512-xRc4oEhT6eaBpU1XF7AjpOFD+xQmXNB5OVKwp4tqCuBpHLS/ZbBDrc07mYTDqVMg6PfxUjjNp85O6Cd2Z/5HWA==",
+      "license": "MIT",
       "dependencies": {
         "mime-db": "^1.54.0"
       },
@@ -2421,6 +2624,7 @@
       "version": "5.1.6",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
       "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
+      "license": "ISC",
       "dependencies": {
         "brace-expansion": "^2.0.1"
       },
@@ -2433,6 +2637,7 @@
       "version": "17.1.2",
       "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-editor-api/-/monaco-vscode-editor-api-17.1.2.tgz",
       "integrity": "sha512-RohpdBq+PHVc+tdA9kuuiFK1tRrBsAQW1Rc4MjfcJEEF9PAkxdbM9ysXSrhbb0aan5aC9zrURUUshLzIVV1+Qg==",
+      "license": "MIT",
       "dependencies": {
         "@codingame/monaco-vscode-5452e2b7-9081-5f95-839b-4ab3544ce28f-common": "17.1.2",
         "@codingame/monaco-vscode-api": "17.1.2"
@@ -2442,6 +2647,7 @@
       "version": "6.8.0",
       "resolved": "https://registry.npmjs.org/monaco-editor-wrapper/-/monaco-editor-wrapper-6.8.0.tgz",
       "integrity": "sha512-wg8pEY4rsPKEGMl9LeqHVj42/qrzqf8lESY60M6IYK+DkntWwUrP34TcLAADahOpI9qzKirF4QYYgI5e6Br+CA==",
+      "license": "MIT",
       "dependencies": {
         "@codingame/monaco-vscode-api": "~17.1.2",
         "@codingame/monaco-vscode-editor-api": "~17.1.2",
@@ -2482,6 +2688,7 @@
       "version": "9.7.0",
       "resolved": "https://registry.npmjs.org/monaco-languageclient/-/monaco-languageclient-9.7.0.tgz",
       "integrity": "sha512-STybwNkk7dXWnFqhjHnx8kf61La5mDaufkctmqzKQv21ZJ3TlYsBSIjDYdodeM2otHcfzLAkTtdIRCUH/pbPkg==",
+      "license": "MIT",
       "dependencies": {
         "@codingame/monaco-vscode-api": "~17.1.2",
         "@codingame/monaco-vscode-configuration-service-override": "~17.1.2",
@@ -2511,6 +2718,7 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "license": "MIT",
       "bin": {
         "nanoid": "bin/nanoid.cjs"
       },
@@ -2521,17 +2729,20 @@
     "node_modules/pend": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
-      "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg=="
+      "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
+      "license": "MIT"
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
-      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "license": "ISC"
     },
     "node_modules/picomatch": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
       "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
+      "license": "MIT",
       "engines": {
         "node": ">=12"
       },
@@ -2557,6 +2768,7 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "license": "MIT",
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -2570,6 +2782,7 @@
       "version": "4.41.1",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.41.1.tgz",
       "integrity": "sha512-cPmwD3FnFv8rKMBc1MxWCwVQFxwf1JEmSX3iQXrRVVG15zerAIXRjMFVWnd5Q5QvgKF7Aj+5ykXFhUl+QGnyOw==",
+      "license": "MIT",
       "dependencies": {
         "@types/estree": "1.0.7"
       },
@@ -2608,6 +2821,7 @@
       "version": "7.7.2",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
       "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
+      "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -2619,6 +2833,7 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
       "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -2626,12 +2841,14 @@
     "node_modules/thenby": {
       "version": "1.3.4",
       "resolved": "https://registry.npmjs.org/thenby/-/thenby-1.3.4.tgz",
-      "integrity": "sha512-89Gi5raiWA3QZ4b2ePcEwswC3me9JIg+ToSgtE0JWeCynLnLxNr/f9G+xfo9K+Oj4AFdom8YNJjibIARTJmapQ=="
+      "integrity": "sha512-89Gi5raiWA3QZ4b2ePcEwswC3me9JIg+ToSgtE0JWeCynLnLxNr/f9G+xfo9K+Oj4AFdom8YNJjibIARTJmapQ==",
+      "license": "Apache-2.0"
     },
     "node_modules/thingies": {
       "version": "1.21.0",
       "resolved": "https://registry.npmjs.org/thingies/-/thingies-1.21.0.tgz",
       "integrity": "sha512-hsqsJsFMsV+aD4s3CWKk85ep/3I9XzYV/IXaSouJMYIoDlgyi11cBhsqYe9/geRfB0YIikBQg6raRaM+nIMP9g==",
+      "license": "Unlicense",
       "engines": {
         "node": ">=10.18"
       },
@@ -2643,6 +2860,7 @@
       "version": "0.2.14",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.14.tgz",
       "integrity": "sha512-tX5e7OM1HnYr2+a2C/4V0htOcSQcoSTH9KgJnVvNm5zm/cyEWKJ7j7YutsH9CxMdtOkkLFy2AHrMci9IM8IPZQ==",
+      "license": "MIT",
       "dependencies": {
         "fdir": "^6.4.4",
         "picomatch": "^4.0.2"
@@ -2658,6 +2876,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/tree-dump/-/tree-dump-1.0.3.tgz",
       "integrity": "sha512-il+Cv80yVHFBwokQSfd4bldvr1Md951DpgAGfmhydt04L+YzHgubm2tQ7zueWDcGENKHq0ZvGFR/hjvNXilHEg==",
+      "license": "Apache-2.0",
       "engines": {
         "node": ">=10.0"
       },
@@ -2672,12 +2891,27 @@
     "node_modules/tslib": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/typescript": {
+      "version": "5.8.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
+      "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
     },
     "node_modules/vite": {
       "version": "6.3.5",
       "resolved": "https://registry.npmjs.org/vite/-/vite-6.3.5.tgz",
       "integrity": "sha512-cZn6NDFE7wdTpINgs++ZJ4N49W2vRp8LCKrn3Ob1kYNtOo21vfDoaV5GzBfLU4MovSAB8uNRm4jgzVQZ+mBzPQ==",
+      "license": "MIT",
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",
@@ -2748,28 +2982,23 @@
       }
     },
     "node_modules/vscode": {
-      "name": "@codingame/monaco-vscode-api",
+      "name": "@codingame/monaco-vscode-extension-api",
       "version": "17.1.2",
-      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-api/-/monaco-vscode-api-17.1.2.tgz",
-      "integrity": "sha512-wu2G1lIfrr9DOIJMo9rKopxp/hi/wnIeSK5seCma5Pg/YJDUOPKjl1i2zdC7qSanrALuYxq0S8+QzETCVpr+ag==",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-extension-api/-/monaco-vscode-extension-api-17.1.2.tgz",
+      "integrity": "sha512-jo5iA5edcskc4M5f7mVwq+dL/pE24d7Kja/80VQbF6VPC0ounfQwTjgOb+bY3FTg6jaFL1Gj6qrgaM8tnW81eQ==",
+      "license": "MIT",
       "dependencies": {
-        "@codingame/monaco-vscode-base-service-override": "17.1.2",
-        "@codingame/monaco-vscode-environment-service-override": "17.1.2",
-        "@codingame/monaco-vscode-extensions-service-override": "17.1.2",
-        "@codingame/monaco-vscode-files-service-override": "17.1.2",
-        "@codingame/monaco-vscode-host-service-override": "17.1.2",
-        "@codingame/monaco-vscode-layout-service-override": "17.1.2",
-        "@codingame/monaco-vscode-quickaccess-service-override": "17.1.2",
-        "@vscode/iconv-lite-umd": "0.7.0",
-        "dompurify": "3.2.6",
-        "jschardet": "3.1.4",
-        "marked": "14.0.0"
+        "@codingame/monaco-vscode-34a0ffd3-b9f5-5699-b43b-38af5732f38a-common": "17.1.2",
+        "@codingame/monaco-vscode-4a3ac544-9a61-534c-88df-756262793ef7-common": "17.1.2",
+        "@codingame/monaco-vscode-api": "17.1.2",
+        "@codingame/monaco-vscode-extensions-service-override": "17.1.2"
       }
     },
     "node_modules/vscode-jsonrpc": {
       "version": "8.2.0",
       "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.2.0.tgz",
       "integrity": "sha512-C+r0eKJUIfiDIfwJhria30+TYWPtuHJXHtI7J0YlOmKAo7ogxP20T0zxB7HZQIFhIyvoBPwWskjxrvAtfjyZfA==",
+      "license": "MIT",
       "engines": {
         "node": ">=14.0.0"
       }
@@ -2778,6 +3007,7 @@
       "version": "9.0.1",
       "resolved": "https://registry.npmjs.org/vscode-languageclient/-/vscode-languageclient-9.0.1.tgz",
       "integrity": "sha512-JZiimVdvimEuHh5olxhxkht09m3JzUGwggb5eRUkzzJhZ2KjCN0nh55VfiED9oez9DyF8/fz1g1iBV3h+0Z2EA==",
+      "license": "MIT",
       "dependencies": {
         "minimatch": "^5.1.0",
         "semver": "^7.3.7",
@@ -2791,6 +3021,7 @@
       "version": "3.17.5",
       "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.5.tgz",
       "integrity": "sha512-mb1bvRJN8SVznADSGWM9u/b07H7Ecg0I3OgXDuLdn307rl/J3A9YD6/eYOssqhecL27hK1IPZAsaqh00i/Jljg==",
+      "license": "MIT",
       "dependencies": {
         "vscode-jsonrpc": "8.2.0",
         "vscode-languageserver-types": "3.17.5"
@@ -2799,22 +3030,26 @@
     "node_modules/vscode-languageserver-types": {
       "version": "3.17.5",
       "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.5.tgz",
-      "integrity": "sha512-Ld1VelNuX9pdF39h2Hgaeb5hEZM2Z3jUrrMgWQAu82jMtZp7p3vJT3BzToKtZI7NgQssZje5o0zryOrhQvzQAg=="
+      "integrity": "sha512-Ld1VelNuX9pdF39h2Hgaeb5hEZM2Z3jUrrMgWQAu82jMtZp7p3vJT3BzToKtZI7NgQssZje5o0zryOrhQvzQAg==",
+      "license": "MIT"
     },
     "node_modules/vscode-oniguruma": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/vscode-oniguruma/-/vscode-oniguruma-1.7.0.tgz",
-      "integrity": "sha512-L9WMGRfrjOhgHSdOYgCt/yRMsXzLDJSL7BPrOZt73gU0iWO4mpqzqQzOz5srxqTvMBaR0XZTSrVWo4j55Rc6cA=="
+      "integrity": "sha512-L9WMGRfrjOhgHSdOYgCt/yRMsXzLDJSL7BPrOZt73gU0iWO4mpqzqQzOz5srxqTvMBaR0XZTSrVWo4j55Rc6cA==",
+      "license": "MIT"
     },
     "node_modules/vscode-textmate": {
       "version": "9.2.0",
       "resolved": "https://registry.npmjs.org/vscode-textmate/-/vscode-textmate-9.2.0.tgz",
-      "integrity": "sha512-rkvG4SraZQaPSN/5XjwKswdU0OP9MF28QjrYzUBbhb8QyG3ljB1Ky996m++jiI7KdiAP2CkBiQZd9pqEDTClqA=="
+      "integrity": "sha512-rkvG4SraZQaPSN/5XjwKswdU0OP9MF28QjrYzUBbhb8QyG3ljB1Ky996m++jiI7KdiAP2CkBiQZd9pqEDTClqA==",
+      "license": "MIT"
     },
     "node_modules/vscode-ws-jsonrpc": {
       "version": "3.4.0",
       "resolved": "https://registry.npmjs.org/vscode-ws-jsonrpc/-/vscode-ws-jsonrpc-3.4.0.tgz",
       "integrity": "sha512-jkNZvX0LdHt4skPxMw/jFePr3jRCJU6ZmO28oPoQ7RwNSkwU3uN8mgtxACYEbOY68bYmi/b/uJzhxewKCz1P4w==",
+      "license": "MIT",
       "dependencies": {
         "vscode-jsonrpc": "~8.2.1"
       },
@@ -2827,6 +3062,7 @@
       "version": "8.2.1",
       "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.2.1.tgz",
       "integrity": "sha512-kdjOSJ2lLIn7r1rtrMbbNCHjyMPfRnowdKjBQ+mGq6NAW5QY2bEZC/khaC5OR8svbbjvLEaIXkOq45e2X9BIbQ==",
+      "license": "MIT",
       "engines": {
         "node": ">=14.0.0"
       }
@@ -2835,6 +3071,7 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-3.2.0.tgz",
       "integrity": "sha512-Ow9nuGZE+qp1u4JIPvg+uCiUr7xGQWdff7JQSk5VGYTAZMDe2q8lxJ10ygv10qmSj031Ty/6FNJpLO4o1Sgc+w==",
+      "license": "MIT",
       "dependencies": {
         "buffer-crc32": "~0.2.3",
         "pend": "~1.2.0"

--- a/package.json
+++ b/package.json
@@ -3,29 +3,27 @@
   "version": "1.0.0",
   "description": "",
   "main": "index.js",
+  "type": "module",
   "scripts": {
-    "dev": "vite"
+    "dev": "vite",
+    "watch:tsc": "tsc -p tsconfig.json --watch"
   },
   "keywords": [],
   "author": "",
   "license": "ISC",
   "dependencies": {
     "@codingame/esbuild-import-meta-url-plugin": "^1.0.3",
-    "@codingame/monaco-vscode-editor-api": "^17.1.2",
-    "@codingame/monaco-vscode-api": "^17.1.2",
-    "@codingame/monaco-vscode-extensions-service-override": "^17.1.2",
-    "@codingame/monaco-vscode-json-default-extension": "^17.1.2",
-    "@codingame/monaco-vscode-keybindings-service-override": "^17.1.2",
-    "@codingame/monaco-vscode-rollup-vsix-plugin": "^17.1.2",
-    "@codingame/monaco-vscode-textmate-service-override": "^17.1.2",
-    "@codingame/monaco-vscode-theme-service-override": "^17.1.2",
-    "monaco-editor": "npm:@codingame/monaco-vscode-editor-api@~17.1.2",
-    "monaco-editor-wrapper": "^6.8.0",
-    "monaco-languageclient": "^9.7.0",
+    "@codingame/monaco-vscode-api": "~17.1.2",
+    "@codingame/monaco-vscode-editor-api": "~17.1.2",
+    "@codingame/monaco-vscode-rollup-vsix-plugin": "~17.1.2",
+    "@codingame/monaco-vscode-standalone-languages": "~17.1.2",
+    "monaco-editor-wrapper": "~6.8.0",
+    "monaco-languageclient": "~9.7.0",
+    "typescript": "~5.8.3",
     "vite": "^6.3.5",
     "vscode": "npm:@codingame/monaco-vscode-extension-api@~17.1.2"
   },
   "devDependencies": {
-    "@types/vscode": "^1.100.0"
+    "@types/vscode": "~1.100.0"
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,25 @@
+ {
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "lib": [
+      "ES2022",
+      "DOM",
+      "DOM.Iterable"
+    ],
+    "skipLibCheck": true,
+    "verbatimModuleSyntax": true,
+    "rootDir": ".",
+    "noEmit": true
+  },
+
+  "include": [
+    "**/*.ts"
+  ],
+  "exclude": [
+    "dist/**/*",
+    "lib/**/*",
+    "node_modules/**/*"
+  ]
+}

--- a/vite.config.mjs
+++ b/vite.config.mjs
@@ -3,81 +3,19 @@ import importMetaUrlPlugin from '@codingame/esbuild-import-meta-url-plugin';
 import vsixPlugin from '@codingame/monaco-vscode-rollup-vsix-plugin';
 
 export default defineConfig({
-
 	optimizeDeps: {
 		esbuildOptions: {
 			plugins: [
 				importMetaUrlPlugin
 			]
 		},
+		// only required for loading vsix directly
 		plugins: [vsixPlugin()],
 		include: [
-			"monaco-languageclient",
 			'@codingame/monaco-vscode-api',
-			'@codingame/monaco-vscode-configuration-service-override',
-			'@codingame/monaco-vscode-cpp-default-extension',
-			'@codingame/monaco-vscode-debug-service-override',
-			'@codingame/monaco-vscode-editor-api',
-			'@codingame/monaco-vscode-editor-service-override',
-			'@codingame/monaco-vscode-environment-service-override',
-			'@codingame/monaco-vscode-explorer-service-override',
-			'@codingame/monaco-vscode-extension-api',
-			'@codingame/monaco-vscode-extensions-service-override',
-			'@codingame/monaco-vscode-files-service-override',
-			'@codingame/monaco-vscode-groovy-default-extension',
-			'@codingame/monaco-vscode-java-default-extension',
-			'@codingame/monaco-vscode-javascript-default-extension',
-			'@codingame/monaco-vscode-json-default-extension',
-			'@codingame/monaco-vscode-keybindings-service-override',
-			'@codingame/monaco-vscode-language-pack-cs',
-			'@codingame/monaco-vscode-language-pack-de',
-			'@codingame/monaco-vscode-language-pack-es',
-			'@codingame/monaco-vscode-language-pack-fr',
-			'@codingame/monaco-vscode-language-pack-it',
-			'@codingame/monaco-vscode-language-pack-ja',
-			'@codingame/monaco-vscode-language-pack-ko',
-			'@codingame/monaco-vscode-language-pack-pl',
-			'@codingame/monaco-vscode-language-pack-pt-br',
-			'@codingame/monaco-vscode-language-pack-qps-ploc',
-			'@codingame/monaco-vscode-language-pack-ru',
-			'@codingame/monaco-vscode-language-pack-tr',
-			'@codingame/monaco-vscode-language-pack-zh-hans',
-			'@codingame/monaco-vscode-language-pack-zh-hant',
-			'@codingame/monaco-vscode-languages-service-override',
-			'@codingame/monaco-vscode-lifecycle-service-override',
-			'@codingame/monaco-vscode-localization-service-override',
-			'@codingame/monaco-vscode-log-service-override',
-			'@codingame/monaco-vscode-model-service-override',
-			'@codingame/monaco-vscode-monarch-service-override',
-			'@codingame/monaco-vscode-preferences-service-override',
-			'@codingame/monaco-vscode-python-default-extension',
-			'@codingame/monaco-vscode-remote-agent-service-override',
-			'@codingame/monaco-vscode-search-result-default-extension',
-			'@codingame/monaco-vscode-search-service-override',
-			'@codingame/monaco-vscode-secret-storage-service-override',
-			'@codingame/monaco-vscode-standalone-css-language-features',
-			'@codingame/monaco-vscode-standalone-html-language-features',
-			'@codingame/monaco-vscode-standalone-json-language-features',
-			'@codingame/monaco-vscode-standalone-languages',
-			'@codingame/monaco-vscode-standalone-typescript-language-features',
-			'@codingame/monaco-vscode-storage-service-override',
-			'@codingame/monaco-vscode-testing-service-override',
-			'@codingame/monaco-vscode-textmate-service-override',
-			'@codingame/monaco-vscode-theme-defaults-default-extension',
-			'@codingame/monaco-vscode-theme-service-override',
-			'@codingame/monaco-vscode-typescript-basics-default-extension',
-			'@codingame/monaco-vscode-typescript-language-features-default-extension',
-			'@codingame/monaco-vscode-views-service-override',
-			'@codingame/monaco-vscode-workbench-service-override',
-			'@testing-library/react',
-			'langium',
-			'langium/lsp',
-			'langium/grammar',
-			'vscode/localExtensionHost',
-			'vscode-textmate',
-			'vscode-oniguruma',
-			'vscode-languageclient',
-			'vscode-languageserver/browser.js'
+			'monaco-languageclient/tools',
+			'monaco-editor-wrapper/workers/workerLoaders',
+			'monaco-editor-wrapper'
 		]
 	},
 	define: {
@@ -87,18 +25,12 @@ export default defineConfig({
 		format: 'es'
 	},
 	server: {
-		port: 20001,
 		cors: {
 			origin: '*'
 		},
 		headers: {
 			'Cross-Origin-Opener-Policy': 'same-origin',
 			'Cross-Origin-Embedder-Policy': 'require-corp',
-		},
-		watch: {
-			ignored: [
-				'**/.chrome/**/*'
-			]
 		}
 	},
 })


### PR DESCRIPTION
It seems the `package-lock.json` was corrupted. I cleaned the dependencies and remove the lock file and node_modules. Then it started to work.

Adding TypeScript was not really changing anything. You can use `npm run watch:tsc` to see if anyting compiles. No code is emitted. This is not required, but helpful.

I added `@codingame/monaco-vscode-standalone-languages` for basic highlighting and changed the code to python, so we can see the highlighting. Json highlighting with monaco requires more worker configuration that I did not want to do right now.